### PR TITLE
Fix build script issues and remove redundant code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,8 +120,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - id: "YouTube"
-          - id: "Music"
+          - id: "YouTube-Extended"
+          - id: "Music-Extended"
           - id: "Reddit"
           - id: "Spotify"
           - id: "X"

--- a/build.sh
+++ b/build.sh
@@ -137,10 +137,10 @@ fi
 # Initialize build.md
 : >build.md
 
-# Clear changelogs
-if [ "$(echo "$TEMP_DIR"/*-rv/changelog.md 2>/dev/null)" ]; then
-	: >"$TEMP_DIR"/*-rv/changelog.md 2>/dev/null || :
-fi
+# Clear changelogs (if any exist)
+for changelog in "$TEMP_DIR"/*-rv/changelog.md; do
+	[ -f "$changelog" ] && : >"$changelog"
+done 2>/dev/null || :
 
 # ==================== Build Processing ====================
 

--- a/utils.sh
+++ b/utils.sh
@@ -21,9 +21,6 @@ NEXT_VER_CODE=${NEXT_VER_CODE:-$(date +'%Y%m%d')}
 # Operating system detection
 OS=$(uname -o)
 
-# Build mode array (can be modified by functions)
-build_mode_arr=(apk module)
-
 # Source all library modules
 LIB_DIR="${CWD}/lib"
 


### PR DESCRIPTION
- Fix build_mode_arr initialization in patching.sh to properly handle all build modes (apk/module/both) as a local variable
- Remove global build_mode_arr from utils.sh (now local to build_rv)
- Simplify merge_splits to just merge without unnecessary signing (signing is handled during the patching step)
- Fix workflow matrix to use correct app names (YouTube-Extended, Music-Extended) matching config.toml
- Fix changelog.md glob handling to avoid errors when no files exist