### PR TITLE
Refactor `scripts/toml_get.py` to remove duplicated logic

### DIFF
--- a/scripts/toml_get.py
+++ b/scripts/toml_get.py
@@ -15,11 +15,53 @@ Requirements:
 Author: ReVanced Builder
 License: Same as parent project
 """
+
 import argparse
 import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+
+
+def _read_and_parse(
+    file_path: Path,
+    parser: Callable[[Any], dict[str, Any]],
+    mode: str,
+    exc_class: type[Exception],
+    format_name: str,
+) -> dict[str, Any]:
+    """
+    Helper to read and parse a file.
+
+    Args:
+        file_path: Path to the file.
+        parser: Function to parse the file content.
+        mode: File open mode ('rb' or 'r').
+        exc_class: Exception class to catch for syntax errors.
+        format_name: Name of the format (for error messages).
+
+    Returns:
+        Dictionary representation of the data.
+
+    Raises:
+        SystemExit: On parsing errors or file access issues.
+    """
+    try:
+        if "b" in mode:
+            with open(file_path, mode) as f:
+                return parser(f)
+        else:
+            with open(file_path, mode, encoding="utf-8") as f:
+                return parser(f)
+    except exc_class as e:
+        print(f"Error: Invalid {format_name} syntax in {file_path}: {e}", file=sys.stderr)
+        sys.exit(2)
+    except Exception as e:
+        print(f"Error reading {format_name} file {file_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
 def parse_toml(file_path: Path) -> dict[str, Any]:
     """
     Parse TOML file and return as dictionary.
@@ -35,15 +77,12 @@ def parse_toml(file_path: Path) -> dict[str, Any]:
     except ImportError:
         print("Error: tomllib not available (Python >= 3.11 required)", file=sys.stderr)
         sys.exit(2)
-    try:
-        with open(file_path, "rb") as f:
-            return tomllib.load(f)
-    except tomllib.TOMLDecodeError as e:
-        print(f"Error: Invalid TOML syntax in {file_path}: {e}", file=sys.stderr)
-        sys.exit(2)
-    except Exception as e:
-        print(f"Error reading TOML file {file_path}: {e}", file=sys.stderr)
-        sys.exit(1)
+
+    return _read_and_parse(
+        file_path, tomllib.load, "rb", tomllib.TOMLDecodeError, "TOML"
+    )
+
+
 def parse_json(file_path: Path) -> dict[str, Any]:
     """
     Parse and validate JSON file.
@@ -54,15 +93,9 @@ def parse_json(file_path: Path) -> dict[str, Any]:
     Raises:
         SystemExit: On parsing errors or file access issues
     """
-    try:
-        with open(file_path, encoding="utf-8") as f:
-            return json.load(f)  # type: ignore[no-any-return]
-    except json.JSONDecodeError as e:
-        print(f"Error: Invalid JSON syntax in {file_path}: {e}", file=sys.stderr)
-        sys.exit(2)
-    except Exception as e:
-        print(f"Error reading JSON file {file_path}: {e}", file=sys.stderr)
-        sys.exit(1)
+    return _read_and_parse(file_path, json.load, "r", json.JSONDecodeError, "JSON")
+
+
 def main() -> None:
     """
     Main entry point for TOML/JSON converter CLI.
@@ -100,5 +133,7 @@ def main() -> None:
         print(json.dumps(data, indent=2, ensure_ascii=False))
     else:
         print(json.dumps(data, separators=(",", ":"), ensure_ascii=False))
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Refactor `scripts/toml_get.py` to remove duplicated logic in `parse_toml` and `parse_json`.

*   **What:** Created a helper function `_read_and_parse` to encapsulate file opening, parsing, and error handling.
*   **Why:** To improve code maintainability and reduce duplication.
*   **Verification:** Verified with manual tests covering valid/invalid inputs, missing files, and unsupported extensions. Passed `mypy` strict type checking and `ruff` linting.
*   **Result:** The code is now cleaner, follows DRY principles, and maintains exact behavioral compatibility.


---
*PR created automatically by Jules for task [6072661581600540493](https://jules.google.com/task/6072661581600540493) started by @Ven0m0*