### PR TITLE
🔒 Fix insecure curl usage in dependency-checker.sh

### DIFF
--- a/scripts/dependency-checker.sh
+++ b/scripts/dependency-checker.sh
@@ -25,7 +25,11 @@ gh_api() {
   if [[ -n "$GITHUB_TOKEN" ]]; then
     headers+=(-H "Authorization: token $GITHUB_TOKEN")
   fi
-  curl -sSL "${headers[@]}" "$GITHUB_API/$endpoint"
+  if command -v gh_req &> /dev/null; then
+    gh_req "$GITHUB_API/$endpoint" "-"
+  else
+    curl -sSL --fail --connect-timeout 10 --max-time 300 "${headers[@]}" "$GITHUB_API/$endpoint"
+  fi
 }
 # Compare two semantic versions
 # Returns: 0 if v1 < v2, 1 if v1 >= v2

--- a/tests/security_repro_zip_slip.py
+++ b/tests/security_repro_zip_slip.py
@@ -3,13 +3,13 @@ import zipfile
 
 
 def create_zip(filename):
-    with zipfile.ZipFile(filename, 'w') as zf:
+    with zipfile.ZipFile(filename, "w") as zf:
         # Standard zip slip
-        zf.writestr('../evil.txt', 'evil content')
+        zf.writestr("../evil.txt", "evil content")
         # Absolute path
          # zf.writestr('/tmp/evil_abs.txt', 'evil abs content')
         # Normal file
-        zf.writestr('good.txt', 'good content')
+        zf.writestr("good.txt", "good content")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     create_zip(sys.argv[1])


### PR DESCRIPTION
*   **What:** Replaced the direct, insecure `curl` call in `scripts/dependency-checker.sh` with a secure implementation.
*   **Risk:** The previous `curl` usage lacked timeouts and failure checks, which could lead to hangs or silent failures. It also did not use the `req` wrapper's reliability features (retries) when available.
*   **Solution:** Modified `gh_api` to use the `gh_req` wrapper (from `scripts/lib/network.sh`) when available, ensuring retries and consistent security headers. Added a robust fallback for standalone mode that uses `curl` with `--fail`, `--connect-timeout`, and `--max-time` flags.

---
*PR created automatically by Jules for task [4863724289524922404](https://jules.google.com/task/4863724289524922404) started by @Ven0m0*