### PR TITLE
🔒 Fix path traversal in Uptodown package name extraction

### DIFF
--- a/scripts/lib/download.sh
+++ b/scripts/lib/download.sh
@@ -128,7 +128,14 @@ get_uptodown_resp() {
 }
 # Get package name from Uptodown
 get_uptodown_pkg_name() {
-  scrape_text "tr.full:nth-child(1) > td:nth-child(3)" <<< "$__UPTODOWN_RESP_PKG__"
+  local pkg_name
+  pkg_name=$(scrape_text "tr.full:nth-child(1) > td:nth-child(3)" <<< "$__UPTODOWN_RESP_PKG__")
+
+  if [[ ! "$pkg_name" =~ ^[a-zA-Z0-9._]+$ ]]; then
+    epr "Invalid package name from Uptodown: $pkg_name"
+    return 1
+  fi
+  echo "$pkg_name"
 }
 # Get available versions from Uptodown
 get_uptodown_vers() {


### PR DESCRIPTION
Fixed path traversal vulnerability in `scripts/lib/download.sh` by sanitizing the output of `get_uptodown_pkg_name`.

---
*PR created automatically by Jules for task [5879990242408480817](https://jules.google.com/task/5879990242408480817) started by @Ven0m0*