### PR TITLE
⚡ Limit find depth for aapt2 search

### DIFF
--- a/scripts/aapt2-optimize.sh
+++ b/scripts/aapt2-optimize.sh
@@ -61,7 +61,7 @@ find_aapt2() {
   # Try to find aapt2 in Android SDK
   if [[ -n "${ANDROID_HOME:-}" ]]; then
     local aapt2_path
-    aapt2_path=$(find "${ANDROID_HOME}/build-tools/" -name "aapt2" -type f 2> /dev/null | sort -V | tail -1)
+    aapt2_path=$(find "${ANDROID_HOME}/build-tools/" -maxdepth 3 -name "aapt2" -type f 2> /dev/null | sort -V | tail -1)
     if [[ -n "$aapt2_path" ]] && [[ -x "$aapt2_path" ]]; then
       echo "$aapt2_path"
       return 0

--- a/tests/security_repro_zip_slip.py
+++ b/tests/security_repro_zip_slip.py
@@ -3,13 +3,13 @@ import zipfile
 
 
 def create_zip(filename):
-    with zipfile.ZipFile(filename, 'w') as zf:
+    with zipfile.ZipFile(filename, "w") as zf:
         # Standard zip slip
-        zf.writestr('../evil.txt', 'evil content')
+        zf.writestr("../evil.txt", "evil content")
         # Absolute path
          # zf.writestr('/tmp/evil_abs.txt', 'evil abs content')
         # Normal file
-        zf.writestr('good.txt', 'good content')
+        zf.writestr("good.txt", "good content")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     create_zip(sys.argv[1])


### PR DESCRIPTION
💡 **What:** Limit `find` depth to 3 levels when searching for `aapt2` in `${ANDROID_HOME}/build-tools/`.

🎯 **Why:** Searching the entire `build-tools` hierarchy recursively is inefficient, especially when `build-tools` contains many versions or deep structures. Limiting depth to 3 levels (e.g., `build-tools/version/aapt2`) is sufficient and significantly faster.

📊 **Measured Improvement:**
No benchmarks were run as per user request, but limiting recursion depth is a standard optimization for `find` when target depth is known.

---
*PR created automatically by Jules for task [15652147138301441709](https://jules.google.com/task/15652147138301441709) started by @Ven0m0*