### PR TITLE
Code Health: Remove unused arguments from scrape_attr in download.sh

### DIFF
--- a/scripts/lib/download.sh
+++ b/scripts/lib/download.sh
@@ -105,8 +105,8 @@ dl_apkmirror() {
         fi
       fi
     fi
-    url=$(echo "$resp" | scrape_attr "a.btn" href --base https://www.apkmirror.com) || return 1
-    url=$(req "$url" - | scrape_attr "span > a[rel = nofollow]" href --base https://www.apkmirror.com) || return 1
+    url=$(echo "$resp" | scrape_attr "a.btn" href) || return 1
+    url=$(req "$url" - | scrape_attr "span > a[rel = nofollow]" href) || return 1
   fi
   if [[ "$is_bundle" = true ]]; then
     log_info "Downloading APK bundle from APKMirror"

--- a/tests/security_repro_zip_slip.py
+++ b/tests/security_repro_zip_slip.py
@@ -3,13 +3,13 @@ import zipfile
 
 
 def create_zip(filename):
-    with zipfile.ZipFile(filename, 'w') as zf:
+    with zipfile.ZipFile(filename, "w") as zf:
         # Standard zip slip
-        zf.writestr('../evil.txt', 'evil content')
+        zf.writestr("../evil.txt", "evil content")
         # Absolute path
          # zf.writestr('/tmp/evil_abs.txt', 'evil abs content')
         # Normal file
-        zf.writestr('good.txt', 'good content')
+        zf.writestr("good.txt", "good content")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     create_zip(sys.argv[1])


### PR DESCRIPTION
Remove unused arguments from scrape_attr in download.sh

The `scrape_attr` function only accepts two arguments (selector and attribute).
The `--base` argument was being ignored and misled readers about the functionality.
This change removes the dead code to improve maintainability.
No functional changes were made as the arguments were already ignored.

Verified by:
- Manual inspection of `scrape_attr` definition.
- Syntax check with `bash -n`.
- Running related tests `tests/test_apkmirror_search.sh`.

---
*PR created automatically by Jules for task [3212302734308755555](https://jules.google.com/task/3212302734308755555) started by @Ven0m0*