### PR TITLE
🧹 Clean up redundant Python version check in scripts/toml_get.py

### DIFF
--- a/scripts/toml_get.py
+++ b/scripts/toml_get.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""TOML/JSON to JSON converter for ReVanced Builder
+"""TOML/JSON to JSON converter for ReVanced Builder.
+
 Converts TOML files to JSON using Python's stdlib tomllib (requires Python >= 3.11).
 Also validates and reformats JSON files.
 Usage:
@@ -18,6 +19,7 @@ License: Same as parent project
 import argparse
 import json
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -33,12 +35,7 @@ def parse_toml(file_path: Path) -> dict[str, Any]:
         SystemExit: On parsing errors or file access issues
     """
     try:
-        import tomllib
-    except ImportError:
-        print("Error: tomllib not available (Python >= 3.11 required)", file=sys.stderr)
-        sys.exit(2)
-    try:
-        with open(file_path, "rb") as f:
+        with file_path.open("rb") as f:
             return tomllib.load(f)
     except tomllib.TOMLDecodeError as e:
         print(f"Error: Invalid TOML syntax in {file_path}: {e}", file=sys.stderr)
@@ -59,7 +56,7 @@ def parse_json(file_path: Path) -> dict[str, Any]:
         SystemExit: On parsing errors or file access issues
     """
     try:
-        with open(file_path, encoding="utf-8") as f:
+        with file_path.open(encoding="utf-8") as f:
             return json.load(f)  # type: ignore[no-any-return]
     except json.JSONDecodeError as e:
         print(f"Error: Invalid JSON syntax in {file_path}: {e}", file=sys.stderr)
@@ -71,6 +68,7 @@ def parse_json(file_path: Path) -> dict[str, Any]:
 
 def main() -> None:
     """Main entry point for TOML/JSON converter CLI.
+
     Parses command-line arguments, reads input file, and outputs JSON.
     """
     parser = argparse.ArgumentParser(description="Convert TOML or JSON file to JSON output")

--- a/tests/security_repro_zip_slip.py
+++ b/tests/security_repro_zip_slip.py
@@ -3,13 +3,13 @@ import zipfile
 
 
 def create_zip(filename):
-    with zipfile.ZipFile(filename, 'w') as zf:
+    with zipfile.ZipFile(filename, "w") as zf:
         # Standard zip slip
-        zf.writestr('../evil.txt', 'evil content')
+        zf.writestr("../evil.txt", "evil content")
         # Absolute path
          # zf.writestr('/tmp/evil_abs.txt', 'evil abs content')
         # Normal file
-        zf.writestr('good.txt', 'good content')
+        zf.writestr("good.txt", "good content")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     create_zip(sys.argv[1])


### PR DESCRIPTION
**What:** The code health issue addressed is the redundant check for `tomllib` availability in `scripts/toml_get.py`. Since `pyproject.toml` and environment checks guarantee Python 3.11+, this check was unnecessary.

**Why:** Removing this check simplifies the code, reduces indentation, and makes the dependency requirements clearer. It also cleans up some linting issues (docstrings, `Path.open` usage).

**Verification:**
- Verified manually by running `python3 scripts/toml_get.py --file config.toml` which parsed successfully.
- Verified error handling by running against a malformed TOML file.
- Ran `scripts/lint.sh --fix` and confirmed `scripts/toml_get.py` is free of lint errors.
- Ran `./check-env.sh` which uses `toml_get.py` and it passed.

**Result:** The script is cleaner and maintains full functionality.

---
*PR created automatically by Jules for task [17138552600516869820](https://jules.google.com/task/17138552600516869820) started by @Ven0m0*