### PR TITLE
🧹 code health: Extract hardcoded fallback architectures to a constant

### DIFF
--- a/scripts/apkmirror_search.py
+++ b/scripts/apkmirror_search.py
@@ -11,6 +11,7 @@ import sys
 from selectolax.parser import HTMLParser, Node
 
 _MIN_ROW_FIELDS = 6  # version, size, bundle, arch, android_ver, dpi
+BASE_ARCHS = ["universal", "noarch", "arm64-v8a + armeabi-v7a"]
 
 
 def get_target_archs(arch: str) -> list[str]:
@@ -22,10 +23,9 @@ def get_target_archs(arch: str) -> list[str]:
     Returns:
         Ordered list of acceptable architectures including fallbacks.
     """
-    base_archs = ["universal", "noarch", "arm64-v8a + armeabi-v7a"]
     if arch == "all":
-        return base_archs
-    return [arch, *base_archs]
+        return BASE_ARCHS
+    return [arch, *BASE_ARCHS]
 
 
 def _row_text_nodes(row: Node) -> list[str]:


### PR DESCRIPTION
* 🎯 **What:** Extracted the hardcoded list of fallback architectures (`["universal", "noarch", "arm64-v8a + armeabi-v7a"]`) in `scripts/apkmirror_search.py` into a module-level constant `BASE_ARCHS`.

* 💡 **Why:** Reduces duplication and prevents inconsistencies if the supported architectures need to be updated in the future.

* ✅ **Verification:** 
  - Ran `bash scripts/lint.sh` and fixed related issues.
  - Ran the unit tests (`uv run python -m unittest discover tests` and `bash tests/test_apkmirror_search.sh`). All tests passed.
  - Reverted unrelated changes from `uv.lock` and `scripts/uptodown_search.py`.

* ✨ **Result:** Improved maintainability without changing runtime behavior.

---
*PR created automatically by Jules for task [6410004058305296277](https://jules.google.com/task/6410004058305296277) started by @Ven0m0*