### PR TITLE
🧪 Add tests for isoneof in scripts/lib/helpers.sh

### DIFF
--- a/tests/test_helpers_isoneof.sh
+++ b/tests/test_helpers_isoneof.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Define CWD for relative paths if not already set
+CWD="${CWD:-$(pwd)}"
+LIB_DIR="${CWD}/scripts/lib"
+
+# Source dependencies
+if [[ -f "${LIB_DIR}/logger.sh" ]]; then
+  source "${LIB_DIR}/logger.sh"
+else
+  echo "Error: logger.sh not found at ${LIB_DIR}/logger.sh"
+  false
+fi
+
+if [[ -f "${LIB_DIR}/helpers.sh" ]]; then
+  source "${LIB_DIR}/helpers.sh"
+else
+  echo "Error: helpers.sh not found at ${LIB_DIR}/helpers.sh"
+  false
+fi
+
+echo "Testing isoneof..."
+
+failed=0
+
+assert_success() {
+  local target="$1"
+  local desc="$2"
+  shift 2
+
+  if isoneof "$target" "$@"; then
+    echo "[PASS] $desc"
+  else
+    echo "[FAIL] $desc (Expected success)"
+    failed=1
+  fi
+}
+
+assert_failure() {
+  local target="$1"
+  local desc="$2"
+  shift 2
+
+  if isoneof "$target" "$@" >/dev/null 2>&1; then
+    echo "[FAIL] $desc (Expected failure)"
+    failed=1
+  else
+    echo "[PASS] $desc"
+  fi
+}
+
+# --- Valid inputs (Expect Success) ---
+assert_success "apk" "Target is the first element" "apk" "module" "both"
+assert_success "module" "Target is the middle element" "apk" "module" "both"
+assert_success "both" "Target is the last element" "apk" "module" "both"
+assert_success "1" "Target is numeric" "2" "1" "3"
+assert_success "hello world" "Target has spaces" "foo" "hello world" "bar"
+assert_success "!@#$" "Target is special characters" "%^&*" "!@#$" "()"
+
+# --- Invalid inputs (Expect Failure) ---
+assert_failure "jar" "Target is not in the list" "apk" "module" "both"
+assert_failure "ap" "Target is a substring of an element" "apk" "module" "both"
+assert_failure "apk" "List is empty"
+assert_failure "" "Target is empty string" "apk" "module" "both"
+assert_failure "apk" "List has empty string, target doesn't match" "" "module" "both"
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "Some tests failed."
+  false
+else
+  echo "All tests passed."
+fi

--- a/tests/test_html_parser.py
+++ b/tests/test_html_parser.py
@@ -1,13 +1,15 @@
-import unittest
-import sys
 import os
-from unittest.mock import MagicMock, patch
+import sys
+import unittest
+from unittest.mock import MagicMock
 
 # Ensure scripts module can be imported
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scripts.html_parser import parse_html, scrape_text, scrape_attribute
 from selectolax.parser import HTMLParser
+
+from scripts.html_parser import parse_html, scrape_attribute, scrape_text
+
 
 class TestHtmlParser(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
🎯 **What:** The `isoneof` function in `scripts/lib/helpers.sh` lacked unit tests, which made it vulnerable to future regressions and reduced confidence when modifying it.
📊 **Coverage:** The new test script (`tests/test_helpers_isoneof.sh`) thoroughly tests:
  - Happy paths: First, middle, and last elements matches.
  - Type diversity: Numeric strings, space-containing strings, and strings with special characters.
  - Failure paths: Missing elements, substring false positives, empty option lists, and empty target strings.
✨ **Result:** Enhanced test coverage that verifies correctness for this commonly used utility, ensuring it handles boundary conditions seamlessly.

---
*PR created automatically by Jules for task [9534113828537314334](https://jules.google.com/task/9534113828537314334) started by @Ven0m0*