### PR TITLE
🧪 Add tests and fix semver_validate in helpers.sh

### DIFF
--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -91,14 +91,17 @@ semver_validate() {
   if [[ -z "$version" ]]; then
     return 1
   fi
-  # Remove metadata suffix (everything after -)
-  version="${version%-*}"
+
   # Remove 'v' prefix if present
   version="${version#v}"
-  # Remove all digits and dots - if anything remains, it's not semver
-  local cleaned="${version//[.0-9]/}"
-  # Valid semver should have nothing left after removing digits and dots
-  [[ ${#cleaned} -eq 0 ]]
+
+  # Strict Semantic Versioning regex (Major.Minor.Patch[-Prerelease][+Build])
+  local semver_regex="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$"
+
+  if [[ "$version" =~ $semver_regex ]]; then
+    return 0
+  fi
+  return 1
 }
 # Convert space-separated list to newline-separated
 # Args:

--- a/tests/test_helpers_semver_validate.sh
+++ b/tests/test_helpers_semver_validate.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Define CWD for relative paths if not already set
+CWD="${CWD:-$(pwd)}"
+LIB_DIR="${CWD}/scripts/lib"
+
+# Source dependencies
+if [[ -f "${LIB_DIR}/logger.sh" ]]; then
+  source "${LIB_DIR}/logger.sh"
+else
+  echo "Error: logger.sh not found at ${LIB_DIR}/logger.sh"
+  false
+fi
+
+if [[ -f "${LIB_DIR}/helpers.sh" ]]; then
+  source "${LIB_DIR}/helpers.sh"
+else
+  echo "Error: helpers.sh not found at ${LIB_DIR}/helpers.sh"
+  false
+fi
+
+echo "Testing semver_validate..."
+
+failed=0
+
+assert_valid() {
+  local input="$1"
+  local desc="$2"
+
+  if semver_validate "$input"; then
+    echo "[PASS] $desc: '$input' -> Valid"
+  else
+    echo "[FAIL] $desc: '$input' -> Invalid (Expected valid)"
+    failed=1
+  fi
+}
+
+assert_invalid() {
+  local input="$1"
+  local desc="$2"
+
+  if semver_validate "$input"; then
+    echo "[FAIL] $desc: '$input' -> Valid (Expected invalid)"
+    failed=1
+  else
+    echo "[PASS] $desc: '$input' -> Invalid as expected"
+  fi
+}
+
+# Run tests
+assert_valid "1.2.3" "Standard semver"
+assert_valid "v1.2.3" "Standard semver with 'v'"
+assert_valid "1.2.3-beta.1" "Pre-release"
+assert_valid "1.2.3+build.123" "Build metadata"
+assert_valid "1.2.3-beta.1+build.123" "Pre-release and build metadata"
+assert_valid "v2.0.0-rc.1" "RC with 'v'"
+assert_valid "0.0.1" "Zero semver"
+assert_valid "10.20.30" "Multi-digit semver"
+
+assert_invalid "v1.2a.3" "Letters in version core"
+assert_invalid "" "Empty string"
+assert_invalid "v" "Just 'v'"
+assert_invalid "1.2.3.4" "Four-part version"
+assert_invalid "1.2" "Two-part version"
+assert_invalid "beta-1.2.3" "Prefix instead of suffix"
+assert_invalid "1.02.3" "Leading zeros"
+assert_invalid "1.2.3-01" "Leading zeros in pre-release"
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "Some tests failed."
+  false
+else
+  echo "All tests passed."
+  true
+fi


### PR DESCRIPTION
🎯 What: Added a test script for the `semver_validate` function to verify valid and invalid semantic versions.
📊 Coverage: Added edge cases testing pre-releases, build metadata, missing parts, bad formats, leading zeros, and strict validation of digits.
✨ Result: Discovered that `semver_validate` was too loose, updated it to use a proper strict regex, resulting in 100% test coverage for all considered SemVer edge cases.

---
*PR created automatically by Jules for task [11952802638052378586](https://jules.google.com/task/11952802638052378586) started by @Ven0m0*