### PR TITLE
🔒 [security fix] Secure temporary file and directory creation in network utilities

### DIFF
--- a/scripts/lib/network.sh
+++ b/scripts/lib/network.sh
@@ -25,18 +25,35 @@ _req() {
   fi
   # Handle temporary file for downloads with proper locking
   local dlp="" lock_fd
+  local cookie_file="${TEMP_DIR}/cookie.txt"
   if [[ "$op" != "-" ]]; then
     # Deterministic hash-based temp path (not mktemp) so concurrent downloads
     # of the same destination share one temp file and correctly serialize on the lock
     mkdir -p "$TEMP_DIR"
     chmod 700 "$TEMP_DIR"
-    dlp="${TEMP_DIR}/tmp.$(printf '%s' "$op" | sha256sum | cut -d' ' -f1)"
-    local lock_file="${dlp}.lock"
+
+    local hash=$(printf '%s' "$op" | sha256sum | cut -d' ' -f1)
+    local work_dir="${TEMP_DIR}/work.${hash}"
+
+    # Atomically create a secure directory for this task
+    if ! mkdir -m 700 "$work_dir" 2>/dev/null; then
+      # If it exists, ensure it's a real directory we own (not a symlink)
+      if [[ -L "$work_dir" || ! -d "$work_dir" || ! -O "$work_dir" ]]; then
+        epr "Security error: temporary directory is invalid or insecure: $work_dir"
+        return 1
+      fi
+    fi
+
+    dlp="${work_dir}/download.tmp"
+    local lock_file="${work_dir}/lock"
+    cookie_file="${work_dir}/cookie.txt"
+
     # Try to acquire exclusive lock (create lock file atomically)
     exec {lock_fd}>"$lock_file" || {
       epr "Failed to create lock file: $lock_file"
       return 1
     }
+
     if ! flock -n "$lock_fd"; then
       # Another process is downloading - wait for lock
       log_info "Waiting for concurrent download: $dlp"
@@ -45,7 +62,6 @@ _req() {
       # Check if the other process actually succeeded
       if [[ -f "$op" ]]; then
         exec {lock_fd}>&- # Close lock file descriptor
-        rm -f "$lock_file"
         log_debug "File was downloaded by other process: $op"
         return 0
       fi
@@ -60,7 +76,7 @@ _req() {
   while [[ "$retry_count" -le "$MAX_RETRIES" ]]; do
     if [[ "$op" = "-" ]]; then
       # Output to stdout
-      if curl -L -c "$TEMP_DIR/cookie.txt" -b "$TEMP_DIR/cookie.txt" \
+      if curl -L -c "$cookie_file" -b "$cookie_file" \
         --connect-timeout "$CONNECTION_TIMEOUT" --max-time 300 \
         --fail -s -S "$@" "$ip"; then
         success=true
@@ -68,7 +84,7 @@ _req() {
       fi
     else
       # Output to file
-      if curl -L -c "$TEMP_DIR/cookie.txt" -b "$TEMP_DIR/cookie.txt" \
+      if curl -L -c "$cookie_file" -b "$cookie_file" \
         --connect-timeout "$CONNECTION_TIMEOUT" --max-time 300 \
         --fail -s -S "$@" "$ip" -o "$dlp"; then
         mv -f "$dlp" "$op"

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -385,19 +385,49 @@ class HttpClient:
             asyncio.get_event_loop().run_until_complete(self._async_client.aclose())
 
 
-def _get_deterministic_temp_path(temp_dir: Path, output_path: str | Path) -> Path:
-    """Generate deterministic temp path based on output path hash.
+def _get_secure_work_dir(temp_dir: Path, output_path: str | Path) -> Path:
+    """Create and validate a secure, deterministic work directory.
 
     Args:
-        temp_dir: Temporary directory.
-        output_path: Target output path.
+        temp_dir: Parent temporary directory.
+        output_path: Target output path for the download.
 
     Returns:
-        Path to temporary file for the download.
+        Path to the secure work directory.
+
+    Raises:
+        RuntimeError: If the directory is insecure or cannot be created.
 
     """
-    path_hash = hashlib.sha256(str(output_path).encode()).hexdigest()[:32]
-    return temp_dir / f"tmp.{path_hash}"
+    path_hash = hashlib.sha256(str(output_path).encode()).hexdigest()
+    work_dir = temp_dir / f"work.{path_hash}"
+
+    try:
+        work_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except FileExistsError:
+        pass
+
+    # Security check: ensure it's a real directory we own (not a symlink)
+    if work_dir.is_symlink() or not work_dir.is_dir():
+        raise RuntimeError(f"Security error: temporary directory is invalid: {work_dir}")
+
+    # Check ownership (UID match)
+    if work_dir.stat().st_uid != os.getuid():
+        raise RuntimeError(f"Security error: temporary directory ownership mismatch: {work_dir}")
+
+    # Ensure restricted permissions
+    try:
+        work_dir.chmod(0o700)
+    except PermissionError:
+        # If we can't chmod but we own it and it's a dir, we proceed if it's already secure enough
+        # or if we are in a restricted environment where chmod is not allowed but mkdir mode was respected.
+        if (work_dir.stat().st_mode & 0o777) != 0o700:
+            # In some environments, we might not be able to set 700 exactly,
+            # but we should at least ensure it's not world-writable.
+            if work_dir.stat().st_mode & 0o002:
+                raise RuntimeError(f"Security error: temporary directory is world-writable: {work_dir}") from None
+
+    return work_dir
 
 
 def download_with_lock(
@@ -426,14 +456,15 @@ def download_with_lock(
     import tempfile
 
     output_path = Path(output).resolve()
-    temp_path = _get_deterministic_temp_path(
-        Path(temp_dir) if temp_dir else Path(tempfile.gettempdir()),
-        output_path,
-    )
-    lock_file = Path(f"{temp_path}.lock")
-    temp_dir_path = temp_path.parent
-    temp_dir_path.mkdir(parents=True, exist_ok=True)
-    temp_dir_path.chmod(0o700)
+    base_temp = Path(temp_dir) if temp_dir else Path(tempfile.gettempdir())
+
+    try:
+        work_dir = _get_secure_work_dir(base_temp, output_path)
+    except RuntimeError:
+        return False
+
+    temp_path = work_dir / "download.tmp"
+    lock_file = work_dir / "lock"
 
     if output_path.exists():
         return True
@@ -490,14 +521,15 @@ async def async_download_with_lock(
     import tempfile
 
     output_path = Path(output).resolve()
-    temp_path = _get_deterministic_temp_path(
-        Path(temp_dir) if temp_dir else Path(tempfile.gettempdir()),
-        output_path,
-    )
-    lock_file = Path(f"{temp_path}.lock")
-    temp_dir_path = temp_path.parent
-    temp_dir_path.mkdir(parents=True, exist_ok=True)
-    temp_dir_path.chmod(0o700)
+    base_temp = Path(temp_dir) if temp_dir else Path(tempfile.gettempdir())
+
+    try:
+        work_dir = _get_secure_work_dir(base_temp, output_path)
+    except RuntimeError:
+        return False
+
+    temp_path = work_dir / "download.tmp"
+    lock_file = work_dir / "lock"
 
     if output_path.exists():
         return True

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -13,7 +13,7 @@ import pytest
 from scripts.utils.network import (
     HttpClient,
     HttpClientConfig,
-    _get_deterministic_temp_path,
+    _get_secure_work_dir,
     aria2c_download,
     download_with_aria2c_fallback,
     download_with_lock,
@@ -48,19 +48,19 @@ class TestHttpClientConfig:
 
 
 # ---------------------------------------------------------------------------
-# _get_deterministic_temp_path
+# _get_secure_work_dir
 # ---------------------------------------------------------------------------
 
 
-class TestGetDeterministicTempPath:
+class TestGetSecureWorkDir:
     def test_same_output_same_temp(self, tmp_path: Path) -> None:
-        p1 = _get_deterministic_temp_path(tmp_path, "/build/app.apk")
-        p2 = _get_deterministic_temp_path(tmp_path, "/build/app.apk")
+        p1 = _get_secure_work_dir(tmp_path, "/build/app.apk")
+        p2 = _get_secure_work_dir(tmp_path, "/build/app.apk")
         assert p1 == p2
 
     def test_different_output_different_temp(self, tmp_path: Path) -> None:
-        p1 = _get_deterministic_temp_path(tmp_path, "/build/app1.apk")
-        p2 = _get_deterministic_temp_path(tmp_path, "/build/app2.apk")
+        p1 = _get_secure_work_dir(tmp_path, "/build/app1.apk")
+        p2 = _get_secure_work_dir(tmp_path, "/build/app2.apk")
         assert p1 != p2
 
 


### PR DESCRIPTION
🎯 **What:** This PR fixes an insecure temporary file and directory creation vulnerability in both the Bash (`scripts/lib/network.sh`) and Python (`scripts/utils/network.py`) network utility modules.

⚠️ **Risk:** The previous implementation used deterministic filenames (based on hashes of output paths) directly within the shared temporary directory. An attacker could pre-create symlinks at these predictable paths to point to sensitive system or user files. When the script then wrote to these paths or changed their permissions/ownership, it could lead to arbitrary file overwrites or unauthorized access.

🛡️ **Solution:**
1.  **Private Subdirectories:** Instead of creating files directly in a shared `$TEMP_DIR`, the scripts now create a private, deterministic subdirectory for each specific task (`work.<hash>`).
2.  **Restricted Permissions:** These directories are created with `mode 700` (read/write/execute only by the owner).
3.  **Explicit Verification:** Before using the directory, the scripts now verify that it is a real directory (not a symlink) and that it is owned by the current user (matching UID).
4.  **Task-Specific Cookies:** The Bash script's shared `cookie.txt` has been moved into the per-task private directory to prevent cross-task cookie leakage or manipulation.
5.  **Robust Error Handling:** The Python implementation includes fallback logic for restricted environments (like some CI/CD or container setups) where `chmod` might be restricted but the initial `mkdir` mode is respected.

All changes have been verified with reproduction scripts that successfully blocked symlink attacks, and existing unit tests pass.

---
*PR created automatically by Jules for task [4788783630902659043](https://jules.google.com/task/4788783630902659043) started by @Ven0m0*