### PR TITLE
🧹 Remove unused import in scripts/lib/version_tracker.py

### DIFF
--- a/scripts/lib/version_tracker.py
+++ b/scripts/lib/version_tracker.py
@@ -14,11 +14,6 @@ from scripts.version_tracker import (
     save_state,
 )
 
-try:
-    from importlib.resources import files
-except ImportError:
-    pass  # type: ignore[no-redef]
-
 __all__ = ["VersionTracker"]
 
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `files` import from `importlib.resources` and its associated `try...except` block in `scripts/lib/version_tracker.py`.
💡 **Why:** Improving code maintainability and readability by cleaning up dead code and the namespace.
✅ **Verification:**
- Ran `uv run ruff check scripts/lib/version_tracker.py` to confirm the unused import warning is resolved.
- Ran `uv run python -m pytest tests/test_version_tracker.py -v` to ensure no regressions (21 tests passed).
✨ **Result:** A cleaner codebase with less unnecessary overhead and fewer lint warnings.

---
*PR created automatically by Jules for task [18113959677340553501](https://jules.google.com/task/18113959677340553501) started by @Ven0m0*