### PR TITLE
🔒 [security fix] Secure temporary file and directory creation in network utilities

### DIFF
--- a/.github/workflows/mise.yml
+++ b/.github/workflows/mise.yml
@@ -17,11 +17,4 @@ jobs:
           install: true # [default: true] run `mise install`
           cache: true # [default: true] cache mise using GitHub's cache
           experimental: true # [default: false] enable experimental features
-          # automatically write this mise.toml file
-          mise_toml: |
-            [tools]
-            shellcheck = "0.9.0"
-          # or, if you prefer .tool-versions:
-          tool_versions: |
-            shellcheck 0.9.0
-      - run: shellcheck scripts/*.sh
+      - run: shellcheck scripts/*.sh scripts/lib/*.sh

--- a/scripts/lib/network.sh
+++ b/scripts/lib/network.sh
@@ -30,7 +30,6 @@ _req() {
     # Deterministic hash-based temp path (not mktemp) so concurrent downloads
     # of the same destination share one temp file and correctly serialize on the lock
     mkdir -p "$TEMP_DIR"
-    chmod 700 "$TEMP_DIR"
 
     local hash=$(printf '%s' "$op" | sha256sum | cut -d' ' -f1)
     local work_dir="${TEMP_DIR}/work.${hash}"

--- a/scripts/lib/network.sh
+++ b/scripts/lib/network.sh
@@ -41,6 +41,17 @@ _req() {
         epr "Security error: temporary directory is invalid or insecure: $work_dir"
         return 1
       fi
+
+      local work_dir_mode
+      work_dir_mode=$(stat -c '%a' -- "$work_dir" 2>/dev/null) || {
+        epr "Security error: failed to inspect temporary directory permissions: $work_dir"
+        return 1
+      }
+
+      if (( (8#"${work_dir_mode}" & 022) != 0 )); then
+        epr "Security error: temporary directory must not be writable by group or others: $work_dir"
+        return 1
+      fi
     fi
 
     dlp="${work_dir}/download.tmp"

--- a/scripts/lib/network.sh
+++ b/scripts/lib/network.sh
@@ -25,18 +25,35 @@ _req() {
   fi
   # Handle temporary file for downloads with proper locking
   local dlp="" lock_fd
+  local cookie_file="${TEMP_DIR}/cookie.txt"
   if [[ "$op" != "-" ]]; then
     # Deterministic hash-based temp path (not mktemp) so concurrent downloads
     # of the same destination share one temp file and correctly serialize on the lock
     mkdir -p "$TEMP_DIR"
     chmod 700 "$TEMP_DIR"
-    dlp="${TEMP_DIR}/tmp.$(printf '%s' "$op" | sha256sum | cut -d' ' -f1)"
-    local lock_file="${dlp}.lock"
+
+    local hash=$(printf '%s' "$op" | sha256sum | cut -d' ' -f1)
+    local work_dir="${TEMP_DIR}/work.${hash}"
+
+    # Atomically create a secure directory for this task
+    if ! mkdir -m 700 "$work_dir" 2>/dev/null; then
+      # If it exists, ensure it's a real directory we own (not a symlink)
+      if [[ -L "$work_dir" || ! -d "$work_dir" || ! -O "$work_dir" ]]; then
+        epr "Security error: temporary directory is invalid or insecure: $work_dir"
+        return 1
+      fi
+    fi
+
+    dlp="${work_dir}/download.tmp"
+    local lock_file="${work_dir}/lock"
+    cookie_file="${work_dir}/cookie.txt"
+
     # Try to acquire exclusive lock (create lock file atomically)
     exec {lock_fd}>"$lock_file" || {
       epr "Failed to create lock file: $lock_file"
       return 1
     }
+
     if ! flock -n "$lock_fd"; then
       # Another process is downloading - wait for lock
       log_info "Waiting for concurrent download: $dlp"
@@ -45,7 +62,6 @@ _req() {
       # Check if the other process actually succeeded
       if [[ -f "$op" ]]; then
         exec {lock_fd}>&- # Close lock file descriptor
-        rm -f "$lock_file"
         log_debug "File was downloaded by other process: $op"
         return 0
       fi
@@ -60,7 +76,7 @@ _req() {
   while [[ "$retry_count" -le "$MAX_RETRIES" ]]; do
     if [[ "$op" = "-" ]]; then
       # Output to stdout
-      if curl -L -c "$TEMP_DIR/cookie.txt" -b "$TEMP_DIR/cookie.txt" \
+      if curl -L -c "$cookie_file" -b "$cookie_file" \
         --connect-timeout "$CONNECTION_TIMEOUT" --max-time 300 \
         --fail -s -S "$@" "$ip"; then
         success=true
@@ -68,7 +84,7 @@ _req() {
       fi
     else
       # Output to file
-      if curl -L -c "$TEMP_DIR/cookie.txt" -b "$TEMP_DIR/cookie.txt" \
+      if curl -L -c "$cookie_file" -b "$cookie_file" \
         --connect-timeout "$CONNECTION_TIMEOUT" --max-time 300 \
         --fail -s -S "$@" "$ip" -o "$dlp"; then
         mv -f "$dlp" "$op"

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -4,24 +4,33 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import fcntl
 import hashlib
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 import httpx
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from types import TracebackType
 
 DEFAULT_TIMEOUT = 300
 DEFAULT_MAX_RETRIES = 4
 DEFAULT_INITIAL_DELAY = 2
+SECURE_MODE = 0o700
+COOKIE_PARTS_MIN = 7
+COOKIE_NAME_INDEX = 5
+COOKIE_VALUE_INDEX = 6
 
 
 @dataclass
@@ -83,17 +92,22 @@ class HttpClient:
         )
         self._async_client: httpx.AsyncClient | None = None
 
-    def __enter__(self) -> HttpClient:
+    def __enter__(self) -> Self:
         """Enter context manager for sync client."""
         return self
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Exit context manager and close clients."""
         self._sync_client.close()
         if self._async_client:
             pass
 
-    async def __aenter__(self) -> HttpClient:
+    async def __aenter__(self) -> Self:
         """Enter async context manager."""
         self._async_client = httpx.AsyncClient(
             timeout=httpx.Timeout(self.config.timeout),
@@ -102,7 +116,12 @@ class HttpClient:
         )
         return self
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Exit async context manager and close clients."""
         if self._async_client:
             await self._async_client.aclose()
@@ -113,16 +132,14 @@ class HttpClient:
         if not self.config.cookie_file or not self.config.cookie_file.exists():
             return {}
         cookies = {}
-        try:
+        with contextlib.suppress(OSError):
             content = self.config.cookie_file.read_text()
             for line in content.splitlines():
                 if line.startswith("#") or not line.strip():
                     continue
                 parts = line.split("\t")
-                if len(parts) >= 7:
-                    cookies[parts[5]] = parts[6]
-        except OSError:
-            pass
+                if len(parts) >= COOKIE_PARTS_MIN:
+                    cookies[parts[COOKIE_NAME_INDEX]] = parts[COOKIE_VALUE_INDEX]
         return cookies
 
     def _build_headers(self, extra_headers: dict[str, str] | None = None) -> dict[str, str]:
@@ -168,7 +185,8 @@ class HttpClient:
 
         if last_exception:
             raise last_exception
-        raise httpx.HTTPError("Request failed after retries")
+        msg = "Request failed after retries"
+        raise httpx.HTTPError(msg)
 
     async def _async_retry_with_backoff(
         self,
@@ -206,7 +224,8 @@ class HttpClient:
 
         if last_exception:
             raise last_exception
-        raise httpx.HTTPError("Request failed after retries")
+        msg = "Request failed after retries"
+        raise httpx.HTTPError(msg)
 
     def _do_request(
         self,
@@ -268,7 +287,8 @@ class HttpClient:
 
         """
         if not self._async_client:
-            raise RuntimeError("Async client not initialized. Use 'async with' context.")
+            msg = "Async client not initialized. Use 'async with' context."
+            raise RuntimeError(msg)
         client = self._async_client
 
         full_headers = self._build_headers(headers)
@@ -281,6 +301,8 @@ class HttpClient:
         if output == "-" or output is None:
             return response.text
 
+        # Use synchronous write_bytes for now to avoid complexity of async file IO
+        # in this utility. If high performance is needed, use anyio or aiofiles.
         output_path = Path(output)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_bytes(response.content)
@@ -380,24 +402,50 @@ class HttpClient:
         """Close the HTTP client and release resources."""
         self._sync_client.close()
         if self._async_client:
-            import asyncio
-
             asyncio.get_event_loop().run_until_complete(self._async_client.aclose())
 
 
-def _get_deterministic_temp_path(temp_dir: Path, output_path: str | Path) -> Path:
-    """Generate deterministic temp path based on output path hash.
+def _get_secure_work_dir(temp_dir: Path, output_path: str | Path) -> Path:
+    """Create and validate a secure, deterministic work directory.
 
     Args:
-        temp_dir: Temporary directory.
-        output_path: Target output path.
+        temp_dir: Parent temporary directory.
+        output_path: Target output path for the download.
 
     Returns:
-        Path to temporary file for the download.
+        Path to the secure work directory.
+
+    Raises:
+        RuntimeError: If the directory is insecure or cannot be created.
 
     """
-    path_hash = hashlib.sha256(str(output_path).encode()).hexdigest()[:32]
-    return temp_dir / f"tmp.{path_hash}"
+    path_hash = hashlib.sha256(str(output_path).encode()).hexdigest()
+    work_dir = temp_dir / f"work.{path_hash}"
+
+    with contextlib.suppress(FileExistsError):
+        work_dir.mkdir(mode=SECURE_MODE, parents=True, exist_ok=True)
+
+    # Security check: ensure it's a real directory we own (not a symlink)
+    if work_dir.is_symlink() or not work_dir.is_dir():
+        msg = f"Security error: temporary directory is invalid: {work_dir}"
+        raise RuntimeError(msg)
+
+    # Check ownership (UID match)
+    if work_dir.stat().st_uid != os.getuid():
+        msg = f"Security error: temporary directory ownership mismatch: {work_dir}"
+        raise RuntimeError(msg)
+
+    # Ensure restricted permissions
+    try:
+        work_dir.chmod(SECURE_MODE)
+    except PermissionError:
+        # If we can't chmod but we own it and it's a dir, we proceed if it's already secure enough
+        # or if we are in a restricted environment where chmod is not allowed but mkdir mode was respected.
+        if (work_dir.stat().st_mode & 0o777) != SECURE_MODE and (work_dir.stat().st_mode & 0o002):
+            msg = f"Security error: temporary directory is world-writable: {work_dir}"
+            raise RuntimeError(msg) from None
+
+    return work_dir
 
 
 def download_with_lock(
@@ -423,48 +471,41 @@ def download_with_lock(
         True if download succeeded or file already exists, False otherwise.
 
     """
-    import tempfile
-
     output_path = Path(output).resolve()
-    temp_path = _get_deterministic_temp_path(
-        Path(temp_dir) if temp_dir else Path(tempfile.gettempdir()),
-        output_path,
-    )
-    lock_file = Path(f"{temp_path}.lock")
-    temp_dir_path = temp_path.parent
-    temp_dir_path.mkdir(parents=True, exist_ok=True)
-    temp_dir_path.chmod(0o700)
+    base_temp = Path(temp_dir) if temp_dir else Path(tempfile.gettempdir())
+
+    try:
+        work_dir = _get_secure_work_dir(base_temp, output_path)
+    except RuntimeError:
+        return False
+
+    temp_path = work_dir / "download.tmp"
+    lock_file = work_dir / "lock"
 
     if output_path.exists():
         return True
 
-    lock_fd = None
     try:
-        lock_fd = open(lock_file, "w")
-        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        with lock_file.open("w") as lock_fd:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
 
-        if output_path.exists():
-            return True
+            if output_path.exists():
+                return True
 
-        client = HttpClient(config)
-        try:
-            client.get(url, temp_path, headers=headers or {})
-            temp_path.replace(output_path)
-            return True
-        finally:
-            client.close()
-    except OSError:
+            with HttpClient(config) as client:
+                client.get(url, temp_path, headers=headers or {})
+                temp_path.replace(output_path)
+                return True
+    except (OSError, RuntimeError):
         return False
     except Exception:
         if temp_path.exists():
             temp_path.unlink()
         return False
     finally:
-        if lock_fd:
-            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
-            lock_fd.close()
         if lock_file.exists():
-            lock_file.unlink()
+            with contextlib.suppress(OSError):
+                lock_file.unlink()
 
 
 async def async_download_with_lock(
@@ -487,45 +528,43 @@ async def async_download_with_lock(
         True if download succeeded or file already exists, False otherwise.
 
     """
-    import tempfile
-
     output_path = Path(output).resolve()
-    temp_path = _get_deterministic_temp_path(
-        Path(temp_dir) if temp_dir else Path(tempfile.gettempdir()),
-        output_path,
-    )
-    lock_file = Path(f"{temp_path}.lock")
-    temp_dir_path = temp_path.parent
-    temp_dir_path.mkdir(parents=True, exist_ok=True)
-    temp_dir_path.chmod(0o700)
+    base_temp = Path(temp_dir) if temp_dir else Path(tempfile.gettempdir())
+
+    try:
+        work_dir = _get_secure_work_dir(base_temp, output_path)
+    except RuntimeError:
+        return False
+
+    temp_path = work_dir / "download.tmp"
+    lock_file = work_dir / "lock"
 
     if output_path.exists():
         return True
 
-    lock_fd = None
     try:
-        lock_fd = open(lock_file, "w")
-        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        # fcntl.flock is blocking. In a truly async environment, we would use
+        # a non-blocking lock or run this in a thread.
+        with lock_file.open("w") as lock_fd:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
 
-        if output_path.exists():
-            return True
+            if output_path.exists():
+                return True
 
-        async with HttpClient(config) as client:
-            await client.async_get(url, temp_path, headers=headers or {})
-            temp_path.replace(output_path)
-            return True
-    except OSError:
+            async with HttpClient(config) as client:
+                await client.async_get(url, temp_path, headers=headers or {})
+                temp_path.replace(output_path)
+                return True
+    except (OSError, RuntimeError):
         return False
     except Exception:
         if temp_path.exists():
             temp_path.unlink()
         return False
     finally:
-        if lock_fd:
-            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
-            lock_fd.close()
         if lock_file.exists():
-            lock_file.unlink()
+            with contextlib.suppress(OSError):
+                lock_file.unlink()
 
 
 def req(
@@ -547,10 +586,8 @@ def req(
     """
     cfg = config or HttpClientConfig()
     client = HttpClient(cfg)
-    try:
+    with client:
         return client.get(url, output)
-    finally:
-        client.close()
 
 
 def gh_req(
@@ -579,10 +616,8 @@ def gh_req(
         headers["Authorization"] = f"Bearer {token}"
 
     client = HttpClient(cfg)
-    try:
+    with client:
         return client.get(url, output, headers=headers)
-    finally:
-        client.close()
 
 
 def gh_dl(
@@ -664,9 +699,6 @@ def aria2c_download(
         True if download succeeded, False otherwise.
 
     """
-    import shutil
-    import subprocess
-
     if not shutil.which("aria2c"):
         return False
 
@@ -686,7 +718,7 @@ def aria2c_download(
     cmd.extend(urls)
 
     try:
-        result = subprocess.run(cmd, capture_output=True)
+        result = subprocess.run(cmd, capture_output=True, check=False)
         return result.returncode == 0
     except OSError:
         return False
@@ -713,8 +745,6 @@ def download_with_aria2c_fallback(
         True if download succeeded, False otherwise.
 
     """
-    import shutil
-
     output_path = Path(output_path)
     if shutil.which("aria2c") and aria2c_download(urls, output_path, max_connections=max_connections):
         return True

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -103,9 +103,7 @@ class HttpClient:
         exc_tb: TracebackType | None,
     ) -> None:
         """Exit context manager and close clients."""
-        self._sync_client.close()
-        if self._async_client:
-            pass
+        self.close()
 
     async def __aenter__(self) -> Self:
         """Enter async context manager."""

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -506,7 +506,10 @@ def download_with_lock(
             with contextlib.suppress(OSError):
                 lock_file.unlink()
 
-
+        with contextlib.suppress(OSError):
+            work_dir_stat = work_dir.stat()
+            if work_dir.is_dir() and work_dir_stat.st_uid == os.getuid():
+                work_dir.rmdir()
 async def async_download_with_lock(
     url: str,
     output: str | Path,

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -437,10 +437,11 @@ def _get_secure_work_dir(temp_dir: Path, output_path: str | Path) -> Path:
     try:
         work_dir.chmod(SECURE_MODE)
     except PermissionError:
-        # If we can't chmod but we own it and it's a dir, we proceed if it's already secure enough
-        # or if we are in a restricted environment where chmod is not allowed but mkdir mode was respected.
-        if (work_dir.stat().st_mode & 0o077) != 0:
-            msg = f"Security error: temporary directory is world-writable: {work_dir}"
+        # If chmod is blocked, only proceed when the directory is already private
+        # to the current user with no group/other permissions.
+        mode = work_dir.stat().st_mode
+        if (mode & 0o077) != 0:
+            msg = f"Security error: temporary directory permissions are too broad: {work_dir}"
             raise RuntimeError(msg) from None
 
     return work_dir

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -441,7 +441,7 @@ def _get_secure_work_dir(temp_dir: Path, output_path: str | Path) -> Path:
     except PermissionError:
         # If we can't chmod but we own it and it's a dir, we proceed if it's already secure enough
         # or if we are in a restricted environment where chmod is not allowed but mkdir mode was respected.
-        if (work_dir.stat().st_mode & 0o777) != SECURE_MODE and (work_dir.stat().st_mode & 0o002):
+        if (work_dir.stat().st_mode & 0o077) != 0:
             msg = f"Security error: temporary directory is world-writable: {work_dir}"
             raise RuntimeError(msg) from None
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -13,7 +13,7 @@ import pytest
 from scripts.utils.network import (
     HttpClient,
     HttpClientConfig,
-    _get_deterministic_temp_path,
+    _get_secure_work_dir,
     aria2c_download,
     download_with_aria2c_fallback,
     download_with_lock,
@@ -48,19 +48,19 @@ class TestHttpClientConfig:
 
 
 # ---------------------------------------------------------------------------
-# _get_deterministic_temp_path
+# _get_secure_work_dir
 # ---------------------------------------------------------------------------
 
 
-class TestGetDeterministicTempPath:
+class TestGetSecureWorkDir:
     def test_same_output_same_temp(self, tmp_path: Path) -> None:
-        p1 = _get_deterministic_temp_path(tmp_path, "/build/app.apk")
-        p2 = _get_deterministic_temp_path(tmp_path, "/build/app.apk")
+        p1 = _get_secure_work_dir(tmp_path, "/build/app.apk")
+        p2 = _get_secure_work_dir(tmp_path, "/build/app.apk")
         assert p1 == p2
 
     def test_different_output_different_temp(self, tmp_path: Path) -> None:
-        p1 = _get_deterministic_temp_path(tmp_path, "/build/app1.apk")
-        p2 = _get_deterministic_temp_path(tmp_path, "/build/app2.apk")
+        p1 = _get_secure_work_dir(tmp_path, "/build/app1.apk")
+        p2 = _get_secure_work_dir(tmp_path, "/build/app2.apk")
         assert p1 != p2
 
 


### PR DESCRIPTION
🎯 **What:** This PR fixes an insecure temporary file and directory creation vulnerability in both the Bash (`scripts/lib/network.sh`) and Python (`scripts/utils/network.py`) network utility modules.

⚠️ **Risk:** The previous implementation used deterministic filenames (based on hashes of output paths) directly within the shared temporary directory. An attacker could pre-create symlinks at these predictable paths to point to sensitive system or user files. When the script then wrote to these paths or changed their permissions/ownership, it could lead to arbitrary file overwrites or unauthorized access.

🛡️ **Solution:**
1.  **Private Subdirectories:** Instead of creating files directly in a shared `$TEMP_DIR`, the scripts now create a private, deterministic subdirectory for each specific task (`work.<hash>`).
2.  **Restricted Permissions:** These directories are created with `mode 700` (read/write/execute only by the owner).
3.  **Explicit Verification:** Before using the directory, the scripts now verify that it is a real directory (not a symlink) and that it is owned by the current user (matching UID).
4.  **Task-Specific Cookies:** The Bash script's shared `cookie.txt` has been moved into the per-task private directory to prevent cross-task cookie leakage or manipulation.
5.  **Robust Error Handling:** The Python implementation includes fallback logic for restricted environments where `chmod` might be restricted but the initial `mkdir` mode is respected.
6.  **CI Fix:** Cleaned up `.github/workflows/mise.yml` to avoid conflicts with the root `mise.toml` which was causing CI failures.

All changes have been verified with reproduction scripts that successfully blocked symlink attacks, and existing unit tests pass.

---
*PR created automatically by Jules for task [4788783630902659043](https://jules.google.com/task/4788783630902659043) started by @Ven0m0*