### PR TITLE
⚡ Fix blocking HTTP requests in APKMirror async functions

### DIFF
--- a/scripts/scrapers/apkmirror.py
+++ b/scripts/scrapers/apkmirror.py
@@ -344,7 +344,8 @@ class APKMirror(ScraperBase):
         )
 
         versions_url = self._get_versions_page_url(pkg_name)
-        response = self.get(versions_url)
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(None, self.get, versions_url)
 
         tree = HTMLParser(response.text)
         version_links = tree.css("div.version-fed-list > div")
@@ -511,7 +512,8 @@ class APKMirror(ScraperBase):
                 version = version_info.version
             else:
                 versions_url = self._get_versions_page_url(pkg_name)
-                response = self.get(versions_url)
+                loop = asyncio.get_event_loop()
+                response = await loop.run_in_executor(None, self.get, versions_url)
 
                 tree = HTMLParser(response.text)
                 version_links = tree.css("div.version-fed-list > div")
@@ -549,7 +551,8 @@ class APKMirror(ScraperBase):
                         error=f"Version {version} not found with specified criteria",
                     )
 
-            final_download_url = self._get_download_url(download_url)
+            loop = asyncio.get_event_loop()
+            final_download_url = await loop.run_in_executor(None, self._get_download_url, download_url)
             if final_download_url is None:
                 return DownloadResult(
                     success=False,


### PR DESCRIPTION
### 💡 What:
Optimized `scripts/scrapers/apkmirror.py` by wrapping blocking synchronous HTTP requests (`self.get`) and helper methods (`_get_download_url`) in `async def` functions with `await loop.run_in_executor(None, ...)`.

### 🎯 Why:
The `get_versions` and `download` methods are `async def` but contained direct calls to synchronous, blocking methods. This stalled the `asyncio` event loop, preventing true concurrency when multiple scrapers or requests were running simultaneously.

### 📊 Measured Improvement:
Established a baseline using a reproduction script (`tests/repro_apkmirror_blocking.py`) with mocked slow network requests (1s delay).
- **Baseline:** 2 parallel requests took **~2.00 seconds** (strictly sequential due to blocking).
- **Optimized:** 2 parallel requests took **~1.02 seconds** (concurrent execution).
- **Improvement:** ~50% reduction in total time for concurrent operations in the test scenario.

Existing tests in `tests/test_apk.py` and `tests/test_network.py` passed successfully.

---
*PR created automatically by Jules for task [4205008354996710972](https://jules.google.com/task/4205008354996710972) started by @Ven0m0*