### PR TITLE
🧹 [code health] add explicit check argument to subprocess.run

### DIFF
--- a/scripts/utils/apk.py
+++ b/scripts/utils/apk.py
@@ -361,6 +361,7 @@ class SplitAPKHandler:
                 result = subprocess.run(
                     ["java", "-jar", str(jar), "merge", "-i", str(bundle_path), "-o", str(output_path)],
                     capture_output=True,
+                    check=False,
                 )
                 return result.returncode == 0
             except OSError:
@@ -484,7 +485,7 @@ class AAPT2Manager:
             cmd += ["--target-densities", ",".join(densities)]
 
         try:
-            result = subprocess.run(cmd, capture_output=True)
+            result = subprocess.run(cmd, capture_output=True, check=False)
             return result.returncode == 0
         except OSError:
             return False

--- a/scripts/utils/java.py
+++ b/scripts/utils/java.py
@@ -94,6 +94,7 @@ class JavaRunner:
                 capture_output=True,
                 text=True,
                 timeout=timeout or self.timeout,
+                check=False,
             )
             logger.debug("Return code: %d", result.returncode)
             if result.stdout:

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -783,7 +783,7 @@ def aria2c_download(
     cmd.extend(urls)
 
     try:
-        result = subprocess.run(cmd, capture_output=True)
+        result = subprocess.run(cmd, capture_output=True, check=False)
         return result.returncode == 0
     except OSError:
         return False


### PR DESCRIPTION
🎯 **What:** Added `check=False` to several `subprocess.run` calls in `scripts/utils/network.py`, `scripts/utils/apk.py`, and `scripts/utils/java.py`.
💡 **Why:** This makes the default behavior explicit, improving code maintainability and satisfying Ruff linting rule `PLW1510` (missing-check-argument).
✅ **Verification:** Verified with `pytest` in `tests/test_network.py` and `tests/test_apk.py`, and confirmed that `ruff` no longer reports `PLW1510` for these files.
✨ **Result:** Improved code health and consistency across the utility modules.

---
*PR created automatically by Jules for task [6263226453867963290](https://jules.google.com/task/6263226453867963290) started by @Ven0m0*