### PR TITLE
🧪 [tests] Add unit tests for format_cache_size in cache.py

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -16,11 +16,11 @@ from scripts.lib.cache import format_cache_size
         (1023, "1023 bytes"),
         (1024, "1.0 KiB"),
         (1536, "1.5 KiB"),
-        (1048576, "1.0 MiB"),
-        (1073741824, "1.0 GiB"),
-        (1099511627776, "1.0 TiB"),
-        (2199023255552, "2.0 TiB"),
-        (1125899906842624, "1024.0 TiB"),
+        (1024**2, "1.0 MiB"),
+        (1024**3, "1.0 GiB"),
+        (1024**4, "1.0 TiB"),
+        (2 * 1024**4, "2.0 TiB"),
+        (1024**5, "1024.0 TiB"),
     ],
 )
 def test_format_cache_size(size_bytes: int, expected: str) -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,28 @@
+"""Tests for the cache management library."""
+
+# ruff: noqa: S101
+from __future__ import annotations
+
+import pytest
+
+from scripts.lib.cache import format_cache_size
+
+
+@pytest.mark.parametrize(
+    ("size_bytes", "expected"),
+    [
+        (0, "0 bytes"),
+        (1, "1 bytes"),
+        (1023, "1023 bytes"),
+        (1024, "1.0 KiB"),
+        (1536, "1.5 KiB"),
+        (1048576, "1.0 MiB"),
+        (1073741824, "1.0 GiB"),
+        (1099511627776, "1.0 TiB"),
+        (2199023255552, "2.0 TiB"),
+        (1125899906842624, "1024.0 TiB"),
+    ],
+)
+def test_format_cache_size(size_bytes: int, expected: str) -> None:
+    """Verify that cache sizes are formatted correctly using IEC units."""
+    assert format_cache_size(size_bytes) == expected

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,4 @@
-"""Tests for the cache management library."""
+"""Tests for scripts/lib/cache.py."""
 
 # ruff: noqa: S101
 from __future__ import annotations

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -12,7 +12,7 @@ from scripts.lib.cache import format_cache_size
     ("size_bytes", "expected"),
     [
         (0, "0 bytes"),
-        (1, "1 bytes"),
+        (1, "1 byte"),
         (1023, "1023 bytes"),
         (1024, "1.0 KiB"),
         (1536, "1.5 KiB"),


### PR DESCRIPTION
🎯 **What:** Add missing unit tests for the `format_cache_size` function in `scripts/lib/cache.py` to ensure reliable byte-to-human-readable conversion.

📊 **Coverage:**
- Boundary cases (0 bytes, 1023 bytes vs 1024 bytes).
- Standard IEC units: KiB, MiB, GiB, TiB.
- Fractional values (e.g., 1.5 KiB).
- Overflow handling for values exceeding the largest defined unit (TiB).

✨ **Result:** Increased test coverage for the cache utility library, providing a safety net for future refactoring of cache management logic.

---
*PR created automatically by Jules for task [4175158519381233800](https://jules.google.com/task/4175158519381233800) started by @Ven0m0*