### PR TITLE
🧪 Add tests for execute_show_command and fix cache size formatting

### DIFF
--- a/scripts/lib/cache.py
+++ b/scripts/lib/cache.py
@@ -278,7 +278,7 @@ def format_cache_size(size_bytes: int) -> str:
     for unit in units:
         if size < 1024 or unit == units[-1]:
             if unit == "bytes":
-                return f"{int(size)} bytes"
+                return f"{int(size)} byte" if size == 1 else f"{int(size)} bytes"
             return f"{size:.1f} {unit}"
         size /= 1024
     return f"{size_bytes} bytes"

--- a/tests/test_version_tracker.py
+++ b/tests/test_version_tracker.py
@@ -1,15 +1,18 @@
 """Tests for scripts/version_tracker.py and scripts/lib/version_tracker.py."""
 
-# ruff: noqa: S101, PLC0415, TC003
+# ruff: noqa: S101, PLC0415, TC003, TC002
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from scripts.version_tracker import (
     CheckResult,
     VersionDiff,
     detect_changes,
+    execute_show_command,
     extract_current_versions,
     load_state,
     save_state,
@@ -221,3 +224,29 @@ class TestVersionTrackerWrapper:
             vt_mod.load_state.cache_clear()
 
         assert state.get("global_cli_version") == "5.0.0"
+
+
+# ---------------------------------------------------------------------------
+# execute_show_command
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteShowCommand:
+    def test_execute_show_command_with_state(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        state_file = tmp_path / "state.json"
+        save_state({"test_key": "test_value"}, state_path=state_file)
+
+        result = execute_show_command(state_file)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert '"test_key": "test_value"' in captured.out
+
+    def test_execute_show_command_empty(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        state_file = tmp_path / "empty.json"
+
+        result = execute_show_command(state_file)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "{}"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing tests for `execute_show_command` in `scripts/version_tracker.py`. An additional issue was resolved where `test_format_cache_size[1-1 byte]` failed.
📊 **Coverage:** Two new tests were added for `execute_show_command` (`test_execute_show_command_with_state` and `test_execute_show_command_empty`) to `tests/test_version_tracker.py`, increasing code coverage for state viewing. Also fixed the cache format size test for the singular 'byte' formatting.
✨ **Result:** Improved test coverage and reliability of the version tracker module.

---
*PR created automatically by Jules for task [9901636533776083093](https://jules.google.com/task/9901636533776083093) started by @Ven0m0*