### PR TITLE
🧹 [code health] move shutil import to top level in apkmirror scraper

### DIFF
--- a/scripts/scrapers/apkmirror.py
+++ b/scripts/scrapers/apkmirror.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import shutil
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
@@ -450,8 +451,6 @@ class APKMirror(ScraperBase):
             check=True,
         )
 
-        import shutil
-
         shutil.move(str(zip_path), str(output_path))
 
         for cleanup in (extract_dir, bundle_path.with_suffix(".mzip")):
@@ -591,8 +590,6 @@ class APKMirror(ScraperBase):
         """Close the scraper and clean up resources."""
         super().close()
         if self._temp_dir is not None:
-            import shutil
-
             shutil.rmtree(self._temp_dir, ignore_errors=True)
             self._temp_dir = None
 


### PR DESCRIPTION
🎯 **What:** Moved `import shutil` from local function scope to the top level of the file and removed two instances of the local import.
💡 **Why:** Having imports at the top of the file follows standard Python conventions (PEP 8) and project standards, making it easier to track dependencies and improving readability.
✅ **Verification:** Ran `uv run ruff check` and `uv run ruff format` with no errors. Ran `uv run pytest` successfully.
✨ **Result:** Cleaned up import statement scopes in the apkmirror scraper module.

---
*PR created automatically by Jules for task [11062485994272636008](https://jules.google.com/task/11062485994272636008) started by @Ven0m0*