### PR TITLE
🧹 [Code Health] Move local standard library imports to top of network.py

### DIFF
--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -4,10 +4,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import fcntl
 import hashlib
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -466,7 +470,6 @@ def _verify_or_remove(file_path: Path, sha256: str | None) -> bool:
         return True
     if _calculate_sha256(file_path) == sha256:
         return True
-    import contextlib
 
     with contextlib.suppress(OSError):
         file_path.unlink()
@@ -498,8 +501,6 @@ def download_with_lock(
         True if download succeeded or file already exists, False otherwise.
 
     """
-    import tempfile
-
     output_path = Path(output).resolve()
     base_temp = Path(temp_dir) if temp_dir else Path(tempfile.gettempdir())
 
@@ -570,8 +571,6 @@ async def async_download_with_lock(
         True if download succeeded or file already exists, False otherwise.
 
     """
-    import tempfile
-
     output_path = Path(output).resolve()
     base_temp = Path(temp_dir) if temp_dir else Path(tempfile.gettempdir())
 
@@ -597,7 +596,6 @@ async def async_download_with_lock(
         return fd.fileno()
 
     def _release_lock(fileno: int) -> None:
-        import contextlib
         fcntl.flock(fileno, fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
             os.close(fileno)
@@ -770,9 +768,6 @@ def aria2c_download(
         True if download succeeded, False otherwise.
 
     """
-    import shutil
-    import subprocess
-
     if not shutil.which("aria2c"):
         return False
 
@@ -819,8 +814,6 @@ def download_with_aria2c_fallback(
         True if download succeeded, False otherwise.
 
     """
-    import shutil
-
     output_path = Path(output_path)
     if shutil.which("aria2c") and aria2c_download(urls, output_path, max_connections=max_connections):
         return True


### PR DESCRIPTION
🎯 **What:** Moved local imports (`contextlib`, `shutil`, `subprocess`, `tempfile`) from inside multiple functions to the module level in `scripts/utils/network.py`.
💡 **Why:** Having standard library imports at the top of the file avoids runtime import overhead during function execution, improves readability, and adheres to standard Python conventions (PEP 8) as well as avoiding Ruff PLC0415 violations.
✅ **Verification:** Ran `uv run ruff check`, `uv run ruff format`, and `uv run pytest tests/test_network.py` to verify that all format/lint checks pass and no functionality was broken.
✨ **Result:** Cleaned up the file structure, resolved the code health issue, and slightly improved execution performance for repeatedly called network utility functions.

---
*PR created automatically by Jules for task [18434636497007657801](https://jules.google.com/task/18434636497007657801) started by @Ven0m0*