### PR TITLE
🧹 log OSError when copying APK bundles

### DIFF
--- a/scripts/utils/apk.py
+++ b/scripts/utils/apk.py
@@ -1,5 +1,6 @@
 """APK operations module for signing, aligning, and merging split APKs."""
 
+import logging
 import re
 import shutil
 import subprocess
@@ -7,6 +8,8 @@ import tempfile
 import zipfile
 from enum import Enum
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class APKSigner:
@@ -351,7 +354,8 @@ class SplitAPKHandler:
             try:
                 shutil.copy2(bundle_path, output_path)
                 return True
-            except OSError:
+            except OSError as e:
+                logger.error("Failed to copy APK bundle: %s", e)
                 return False
         if bundle_type in (BundleType.XAPK, BundleType.APKM):
             jar = self._find_apkeditor()

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -598,6 +598,7 @@ async def async_download_with_lock(
 
     def _release_lock(fileno: int) -> None:
         import contextlib
+
         fcntl.flock(fileno, fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
             os.close(fileno)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,7 +202,9 @@ class TestConfigLoader:
 
 
 class TestConfig:
-    def _make_config(self, apps: dict[str, AppConfig], modules: dict[str, dict[str, ModuleConfig]] | None = None) -> Config:
+    def _make_config(
+        self, apps: dict[str, AppConfig], modules: dict[str, dict[str, ModuleConfig]] | None = None
+    ) -> Config:
         return Config(
             global_settings=GlobalConfig(),
             apps=apps,


### PR DESCRIPTION
* 🎯 **What:** The code health issue addressed is a silently swallowed `OSError` exception in `SplitAPKHandler.merge_splits` during the simple case of copying an `.apk` bundle to an output path.
* 💡 **Why:** Silently returning `False` when `shutil.copy2` fails makes it difficult for developers to diagnose why a build pipeline might have failed during the merging phase, especially when dealing with filesystem or permission issues. Logging the error text makes the debugging experience much easier and more transparent.
* ✅ **Verification:** 
  - Ran `uv run pytest` to run the full, extensive test suite, ensuring no functionality or assumptions around `False` failure modes were broken.
  - Ran `./scripts/lint.sh` and resolved unassociated Ruff warnings, verifying the new code meets linting guidelines.
  - Requested Code Review, which evaluated and accepted the logging implementation as safe and complete.
* ✨ **Result:** When an `OSError` occurs during bundle merging, an error log containing the exception details is correctly emitted before cleanly returning `False`. Maintainability is improved by standardizing logging in the `scripts/utils/apk.py` module.

---
*PR created automatically by Jules for task [17701271019243168840](https://jules.google.com/task/17701271019243168840) started by @Ven0m0*