### PR TITLE
🧹 Log OSError when failing to copy an APK in merge_splits

### DIFF
--- a/scripts/utils/apk.py
+++ b/scripts/utils/apk.py
@@ -1,5 +1,6 @@
 """APK operations module for signing, aligning, and merging split APKs."""
 
+import logging
 import re
 import shutil
 import subprocess
@@ -7,6 +8,8 @@ import tempfile
 import zipfile
 from enum import Enum
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class APKSigner:
@@ -351,7 +354,8 @@ class SplitAPKHandler:
             try:
                 shutil.copy2(bundle_path, output_path)
                 return True
-            except OSError:
+            except OSError as e:
+                logger.error("Failed to copy APK: %s", e)
                 return False
         if bundle_type in (BundleType.XAPK, BundleType.APKM):
             jar = self._find_apkeditor()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed: Added logging to the bare `OSError` catch block in `SplitAPKHandler.merge_splits`.
💡 **Why:** How this improves maintainability: Logging the exception message makes debugging file IO issues much easier without suppressing the root cause silently.
✅ **Verification:** How you confirmed the change is safe: Ran the full test suite `uv run pytest` and verified the code format with `uv run ruff check` and `uv run ruff format`. All tests passed.
✨ **Result:** The improvement achieved: Maintainability is improved since we will know why an APK copying fails.

---
*PR created automatically by Jules for task [10741170131335751054](https://jules.google.com/task/10741170131335751054) started by @Ven0m0*