### PR TITLE
🧹 Add logging to module_gen.py version parsing exception handler

### DIFF
--- a/scripts/builder/module_gen.py
+++ b/scripts/builder/module_gen.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 import tempfile
 import zipfile
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class ModuleType(Enum):
@@ -338,5 +341,5 @@ class ModuleGenerator:
                 patch = int(parts[2]) if len(parts) > 2 else 0
                 return str(major + minor + patch)
             except ValueError:
-                pass
+                logger.warning("Failed to parse version '%s' into numeric parts", version)
         return "1000"


### PR DESCRIPTION
🎯 **What:** Handled a previously empty `except ValueError:` block in `scripts/builder/module_gen.py`'s `_version_to_code` method by importing Python's `logging` module, defining a module-level logger, and replacing `pass` with a descriptive `logger.warning()` message.

💡 **Why:** Adding a warning log makes debugging significantly easier by explicitly tracking when new, unhandled versioning schemes fail numeric extraction instead of failing silently. This improves code maintainability.

✅ **Verification:** Verified by passing local Ruff linter checks (`uv run ruff check` and `uv run ruff format`), and running the full project test suite (`uv run pytest`) successfully.

✨ **Result:** Improved module generation error visibility for unexpected version formats without altering functionality.

---
*PR created automatically by Jules for task [14679469338760701845](https://jules.google.com/task/14679469338760701845) started by @Ven0m0*