### PR TITLE
⚡ perf(uptodown): convert _request_with_retry to async

### DIFF
--- a/scripts/scrapers/uptodown.py
+++ b/scripts/scrapers/uptodown.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import re
-import time
 import zipfile
 from dataclasses import dataclass
 from io import BytesIO
@@ -336,7 +335,7 @@ class UptodownScraper(ScraperBase):
             )
 
         try:
-            response = await asyncio.to_thread(self._request_with_retry, target_version.url)
+            response = await self._request_with_retry(target_version.url)
             content = response.content
 
             if target_version.is_xapk:
@@ -455,7 +454,7 @@ class UptodownScraper(ScraperBase):
                 error=f"XAPK extraction failed: {e}",
             )
 
-    def _request_with_retry(self, url: str) -> httpx.Response:
+    async def _request_with_retry(self, url: str) -> httpx.Response:
         """Make HTTP request with retry logic.
 
         Args:
@@ -473,12 +472,12 @@ class UptodownScraper(ScraperBase):
 
         for attempt in range(self.MAX_RETRIES):
             try:
-                response = self.session.get(url)
+                response = await asyncio.to_thread(self.session.get, url)
                 response.raise_for_status()
             except Exception as e:
                 last_error = e
                 if attempt < self.MAX_RETRIES - 1:
-                    time.sleep(delay)
+                    await asyncio.sleep(delay)
                     delay *= 2
             else:
                 return response


### PR DESCRIPTION
💡 **What:** The optimization changes the `_request_with_retry` method to be `async` and uses `await asyncio.sleep` instead of the synchronous `time.sleep`. Only the synchronous network request `self.session.get(url)` is offloaded to the thread pool via `asyncio.to_thread`.
🎯 **Why:** The performance problem was that `time.sleep` was being called from within a thread pool worker (as the entire method was previously run with `asyncio.to_thread`). This meant the retry backoff period effectively held a worker thread hostage for up to 7 seconds on failure, which can lead to thread pool exhaustion and reduced concurrency when downloading or scraping.
📊 **Measured Improvement:** In a local benchmark running the method against an unreachable URL, the original synchronous implementation blocked the thread pool during sleeps, whereas the new implementation allowed asynchronous tasks to continue executing optimally on the event loop, releasing threads while sleeping.

---
*PR created automatically by Jules for task [10027026912780793045](https://jules.google.com/task/10027026912780793045) started by @Ven0m0*