### PR TITLE
Add external-bundles aggregator support and Morphe/Adobo CLI profiles

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,22 +1,13 @@
 name: Setup Build Environment
-description: Sets up Java, Android SDK and Python (via uv) for ReVanced builds
-inputs:
-  python-version:
-    description: Python version to use
-    required: false
-    default: '3.13'
-  java-version:
-    description: Java version to use
-    required: false
-    default: '25'
+description: Sets up Java, Android SDK and Python (via mise + uv) for ReVanced builds
 runs:
   using: composite
   steps:
-  - name: Setup Java
-    uses: actions/setup-java@v5
+  - name: Install mise-managed toolchain (Python, uv, Java)
+    uses: jdx/mise-action@v4.0.1
     with:
-      distribution: temurin
-      java-version: ${{ inputs.java-version }}
+      install: true
+      cache: true
   - name: Setup Android SDK
     uses: android-actions/setup-android@v4
   - name: Cache Android SDK Build Tools
@@ -39,14 +30,9 @@ runs:
         echo "Failed to bootstrap/download pinned bin/*.jar dependencies" >&2
         exit 1
       }
-  - name: Install uv
-    uses: astral-sh/setup-uv@v8.1.0
-    with:
-      enable-cache: true
-      cache-dependency-glob: "uv.lock"
-  - name: Set up Python
+  - name: Install Python dependencies (uv sync)
     shell: bash
-    run: uv python install ${{ inputs.python-version }}
-  - name: Install Python dependencies
+    run: uv sync --locked --all-groups
+  - name: Validate environment (check-env.sh)
     shell: bash
-    run: uv sync --locked
+    run: ./check-env.sh

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -28,19 +28,18 @@ jobs:
       uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 0
-    - name: Setup Java
-      uses: actions/setup-java@v5.2.0
+    - name: Install mise-managed toolchain (Java, Python, uv)
+      uses: jdx/mise-action@v4.0.1
       with:
-        distribution: temurin
-        java-version: '21'
+        install: true
+        cache: true
     - name: Check prerequisites
       id: prereq
       run: |
         echo "## Prerequisites Check" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        # Check for required tools
         MISSING=""
-        for tool in jq zip curl java; do
+        for tool in jq zip curl java uv; do
           if command -v $tool &> /dev/null; then
             echo "✓ $tool" >> $GITHUB_STEP_SUMMARY
           else
@@ -52,7 +51,6 @@ jobs:
           echo "Missing tools:$MISSING"
           exit 1
         fi
-        # Check Java version
         JAVA_VER=$(java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}' | cut -d'.' -f1)
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Java version: $JAVA_VER" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -36,7 +36,7 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
     - name: Set up Python
-      run: uv python install 3.14
+      run: uv python install 3.13
     - name: Install dependencies
       run: uv sync --frozen --all-extras
     - name: Run Ruff Linter
@@ -106,7 +106,7 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
     - name: Set up Python
-      run: uv python install 3.14
+      run: uv python install 3.13
     - name: Setup local bin
       run: mkdir -p "$HOME/.local/bin" && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
     - name: Cache yamlfmt

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Deploy Docs to GitHub Pages
+on:
+  push:
+    branches: [main, master]
+    paths:
+    - docs/**
+    - .github/workflows/pages.yml
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6.0.2
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+    - name: Build with Jekyll
+      uses: actions/jekyll-build-pages@v1
+      with:
+        source: ./docs
+        destination: ./_site
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ The sample config currently enables `Music-Extended` and `YouTube-Extended`; oth
 
 `patches-source` (and `cli-source`) accepts a GitHub repo slug like `owner/repo`. A list of repo slugs is also accepted; later entries override earlier ones when patches conflict. Common choices:
 
-- **ReVanced** — `ReVanced/revanced-patches` + `ReVanced/revanced-cli` (upstream defaults).
-- **ReVanced Extended (RVX)** — `anddea/revanced-patches` + `inotia00/revanced-cli` (current sample config default).
-- **Morphe** — `MorpheApp/morphe-patches` + `MorpheApp/morphe-cli`. Morphed app skeletons live in `config.toml` as `*-Morphed` sections.
+- **Morphe (current default)** — `MorpheApp/morphe-patches` + `MorpheApp/morphe-cli`. Active app sections are `YouTube-Morphed` and `Music-Morphed`.
+- **ReVanced** — `ReVanced/revanced-patches` + `ReVanced/revanced-cli` (upstream).
+- **ReVanced Extended (RVX)** — `anddea/revanced-patches` + `inotia00/revanced-cli`. Sample sections `YouTube-Extended` / `Music-Extended` are shipped disabled; flip `enabled = true` to use them.
 - **Piko** (Twitter/X) — `crimera/piko`.
 - **Patcheddit** (Reddit) — `wchill/patcheddit`.
-- **External bundles** — `brosssh/revanced-external-bundles` for community-curated patch bundles consumed alongside a primary `patches-source`.
-- **Adobo** — `jkennethcarino/adobo` as an alternative patcher CLI. Auto-detected from the JAR's `--help` output; force via `cli-profile = "adobo-cli"` if needed.
+- **External bundles** — `brosssh/revanced-external-bundles` resolves a patch JAR via the community aggregator's GraphQL API (https://revanced-external-bundles.brosssh.com). Use `external-bundles:<bundle_type>` to pin a specific bundle type; the bare repo slug falls back to selecting by the app's package id.
+- **Adobo** — `jkennethcarino/adobo` is a patches collection that runs on top of Morphe CLI. Set `patches-source = "jkennethcarino/adobo"` (and keep `cli-source = "MorpheApp/morphe-cli"`).
 
 Config docs and generators:
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ Common global settings include:
 
 The sample config currently enables `Music-Extended` and `YouTube-Extended`; other app sections are included as examples and are disabled by default.
 
+### Patch sources
+
+`patches-source` (and `cli-source`) accepts a GitHub repo slug like `owner/repo`. A list of repo slugs is also accepted; later entries override earlier ones when patches conflict. Common choices:
+
+- **ReVanced** — `ReVanced/revanced-patches` + `ReVanced/revanced-cli` (upstream defaults).
+- **ReVanced Extended (RVX)** — `anddea/revanced-patches` + `inotia00/revanced-cli` (current sample config default).
+- **Morphe** — `MorpheApp/morphe-patches` + `MorpheApp/morphe-cli`. Morphed app skeletons live in `config.toml` as `*-Morphed` sections.
+- **Piko** (Twitter/X) — `crimera/piko`.
+- **Patcheddit** (Reddit) — `wchill/patcheddit`.
+- **External bundles** — `brosssh/revanced-external-bundles` for community-curated patch bundles consumed alongside a primary `patches-source`.
+- **Adobo** — `jkennethcarino/adobo` as an alternative patcher CLI. Auto-detected from the JAR's `--help` output; force via `cli-profile = "adobo-cli"` if needed.
+
 Config docs and generators:
 
 - [`docs/CONFIG.md`](./docs/CONFIG.md) — config reference

--- a/config.toml
+++ b/config.toml
@@ -37,12 +37,19 @@ cli-version = "dev"
 # - Specific version: e.g., "18.48.39"
 version = "auto"
 
+# Default patcher CLI and patches: Morphe (T2.1).
+# Override per-app via `cli-source` / `patches-source` to fall back to ReVanced or any other ecosystem.
+cli-source = "MorpheApp/morphe-cli"
+patches-source = "MorpheApp/morphe-patches"
+
 # Alternative Patch Sources (for patches-source):
+# - Morphe (default): MorpheApp/morphe-patches
+# - Adobo (Morphe-compatible patches): jkennethcarino/adobo
+# - External Bundles aggregator: brosssh/revanced-external-bundles
 # - ReVanced: ReVanced/revanced-patches
 # - ReVanced Extended (anddea): anddea/revanced-patches
 # - ReVanced Extended (inotia00): inotia00/revanced-patches
 # - De-ReVanced: RookieEnough/De-ReVanced
-# - Morphe: MorpheApp/morphe-patches
 # - Piko (Twitter): crimera/piko
 # - Patcheddit (Reddit): wchill/patcheddit
 
@@ -75,9 +82,9 @@ use-custom-aapt2 = true
 # Required fields: at least one download URL (uptodown-dlurl, apkmirror-dlurl, archive-dlurl, apkpure-dlurl, or aptoide-dlurl)
 # Optional fields: All global settings can be overridden per-app
 # =============================================================================
-# YouTube Music Extended (RVX)
+# YouTube Music Extended (RVX) — opt-in alternative to Morphe defaults.
 [Music-Extended]
-enabled = true
+enabled = false
 app-name = "Music"
 patches-source = "anddea/revanced-patches"
 cli-source = "inotia00/revanced-cli"
@@ -99,9 +106,9 @@ apkmirror-dlurl = "https://apkmirror.com/apk/google-inc/youtube-music"
 archive-dlurl = "https://archive.org/download/jhc-apks/apks/com.google.android.apps.youtube.music"
 apkpure-dlurl = "https://apkpure.net/youtube-music/com.google.android.apps.youtube.music"
 
-# YouTube Extended (RVX)
+# YouTube Extended (RVX) — opt-in alternative to Morphe defaults.
 [YouTube-Extended]
-enabled = true
+enabled = false
 app-name = "YouTube"
 patches-source = "anddea/revanced-patches"
 cli-source = "inotia00/revanced-cli"
@@ -177,14 +184,17 @@ uptodown-dlurl = "https://google-photos.en.uptodown.com/android"
 archive-dlurl = "https://archive.org/download/jhc-apks/apks/com.google.android.apps.photos"
 apkpure-dlurl = "https://apkpure.net/google-photos/com.google.android.apps.photos"
 
-# YouTube Morphed
+# YouTube Morphed (default Morphe build).
 [YouTube-Morphed]
-enabled = false
+enabled = true
 app-name = "YouTube"
 patches-source = "MorpheApp/morphe-patches"
 cli-source = "MorpheApp/morphe-cli"
 rv-brand = "Morphe"
+uptodown-dlurl = "https://youtube.en.uptodown.com/android"
 apkmirror-dlurl = "https://apkmirror.com/apk/google-inc/youtube"
+archive-dlurl = "https://archive.org/download/jhc-apks/apks/com.google.android.youtube"
+apkpure-dlurl = "https://apkpure.net/youtube/com.google.android.youtube"
 
 # YouTube Legacy (Android 6-7)
 [YouTube-Legacy]
@@ -202,14 +212,17 @@ patches-source = "wchill/patcheddit"
 rv-brand = "Patcheddit"
 apkmirror-dlurl = "https://apkmirror.com/apk/redditinc/reddit"
 
-# Music Morphed
+# YouTube Music Morphed (default Morphe build).
 [Music-Morphed]
-enabled = false
+enabled = true
 app-name = "Music"
 patches-source = "MorpheApp/morphe-patches"
 cli-source = "MorpheApp/morphe-cli"
 rv-brand = "Morphe"
+uptodown-dlurl = "https://youtube-music.en.uptodown.com/android"
 apkmirror-dlurl = "https://apkmirror.com/apk/google-inc/youtube-music"
+archive-dlurl = "https://archive.org/download/jhc-apks/apks/com.google.android.apps.youtube.music"
+apkpure-dlurl = "https://apkpure.net/youtube-music/com.google.android.apps.youtube.music"
 
 # Reddit Morphed
 [Reddit-Morphed]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,11 +22,13 @@ compression-level = 9                # module zip compression level
 remove-rv-integrations-checks = true # remove checks from the revanced integrations
 # Multiple patch sources can be specified as an array (patches are merged, later sources override earlier ones on conflicts)
 patches-source = [
-  "anddea/revanced-patches",
-  "jkennethcarino/privacy-revanced-patches"
+  "MorpheApp/morphe-patches",       # default
+  "jkennethcarino/adobo",           # Morphe-compatible add-on patches
+  # "brosssh/revanced-external-bundles",         # resolves via the external-bundles aggregator (matched by package id)
+  # "external-bundles:revanced-patches"          # explicit bundle_type selector
 ]
 # Single source still works for backwards compatibility:
-# patches-source = "revanced/revanced-patches"
+# patches-source = "MorpheApp/morphe-patches"
 cli-source = "j-hc/revanced-cli"             # where to fetch cli from. default: "ReVanced/revanced-cli"
 # Supported CLI flavors (auto-detected from --help): ReVanced CLI v5/v6, Morphe CLI, Adobo CLI.
 # Force a specific profile with cli-profile (default "auto"): "revanced-cli-v5", "revanced-cli-v6", "morphe-cli", "adobo-cli".

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,7 +27,9 @@ patches-source = [
 ]
 # Single source still works for backwards compatibility:
 # patches-source = "revanced/revanced-patches"
-cli-source = "j-hc/revanced-cli"             # where to fetch cli from. default: "j-hc/revanced-cli"
+cli-source = "j-hc/revanced-cli"             # where to fetch cli from. default: "ReVanced/revanced-cli"
+# Supported CLI flavors (auto-detected from --help): ReVanced CLI v5/v6, Morphe CLI, Adobo CLI.
+# Force a specific profile with cli-profile (default "auto"): "revanced-cli-v5", "revanced-cli-v6", "morphe-cli", "adobo-cli".
 # options like cli-source can also set per app
 rv-brand = "ReVanced Extended" # rebrand from 'ReVanced' to something different. default: "ReVanced"
 patches-version = "v2.160.0" # 'latest', 'dev', or a version number. default: "latest"

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,8 +73,8 @@ On mobile (< 768px), the navigation collapses into a hamburger menu.
 
 - `parallel-jobs` — Number of simultaneous builds
 - `compression-level` — ZIP compression (0-9)
-- `patches-source` — Default GitHub repo for patches
-- `cli-source` — ReVanced CLI source
+- `patches-source` — Default GitHub repo for patches (default: `MorpheApp/morphe-patches`). Also accepts `brosssh/revanced-external-bundles` or `external-bundles:<type>` to resolve via the community aggregator.
+- `cli-source` — Patcher CLI source (default: `MorpheApp/morphe-cli`). Profiles supported: ReVanced CLI v5/v6, Morphe, Adobo.
 - `arch` — Default architecture (arm64-v8a, armeabi-v7a, both)
 - `riplib` — Strip unnecessary libraries
 - `enable-aapt2-optimize` — Resource optimization

--- a/docs/generator.html
+++ b/docs/generator.html
@@ -103,13 +103,13 @@
                     </div>
                     <div class="form-group">
                         <label for="patches-source">Default Patches Source</label>
-                        <input type="text" id="patches-source" value="anddea/revanced-patches">
-                        <p class="help-text">GitHub repo (owner/name) for patches</p>
+                        <input type="text" id="patches-source" value="MorpheApp/morphe-patches">
+                        <p class="help-text">GitHub repo (owner/name) for patches. Also accepts `brosssh/revanced-external-bundles` or `external-bundles:&lt;type&gt;`.</p>
                     </div>
                     <div class="form-group">
                         <label for="cli-source">Default CLI Source</label>
-                        <input type="text" id="cli-source" value="inotia00/revanced-cli">
-                        <p class="help-text">GitHub repo for ReVanced CLI</p>
+                        <input type="text" id="cli-source" value="MorpheApp/morphe-cli">
+                        <p class="help-text">GitHub repo for the patcher CLI (Morphe / ReVanced).</p>
                     </div>
                     <div class="form-group">
                         <label for="patches-version">Patches Version</label>

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,7 @@ uvx = true
 bun = true
 
 [tools]
-python = "3.14"
+python = "3.13"
 uv = "latest"
 java = "temurin-25.0.3+9.0.LTS"
 actionlint = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,4 @@
 [settings]
-# gix = true
 experimental = true
 color = true
 yes = true
@@ -10,31 +9,16 @@ lockfile = true
 uv_venv_auto = "create|source"
 uv_venv_create_args = ["--seed", "--system-site-packages"]
 
-[settings.cargo]
-binstall = true
-
-[settings.pipx]
-uvx = true
-
-[settings.npm]
-bun = true
-
 [tools]
+# Core toolchain shared by local dev and CI. Other lint/type/test helpers
+# (mypy, ruff, pytest, prek, ...) live in pyproject.toml dev groups so
+# `uv sync --all-groups` is the single source of truth and `mise install`
+# stays fast and reproducible.
 python = "3.13"
 uv = "latest"
 java = "temurin-25.0.3+9.0.LTS"
-actionlint = "latest"
-action-validator = "latest"
-ruff = "latest"
-ty = "latest"
-prek = "latest"
-"pipx:pytest" = "latest"
-"pipx:basedpyright" = "latest"
 
 [env]
 _.file = { path = ".env", tools = true }
-_.path = ["{{config_root}}/node_modules/.bin"]
 _.python.venv = ".venv"
-NODE_ENV = "{{ env.NODE_ENV | default(value='production') }}"
-MISE_NPM_PACKAGE_MANAGER = "bun"
 PYTHONOPTIMIZE = "1"

--- a/scripts/builder/app_processor.py
+++ b/scripts/builder/app_processor.py
@@ -371,9 +371,9 @@ class AppBuildContext:
     output_path: Path
     source: DownloadSource
     download_url: str = ""
-    patches_source: str | list[str] = "ReVanced/revanced-patches"
+    patches_source: str | list[str] = "MorpheApp/morphe-patches"
     patches_version: str = "latest"
-    cli_source: str = "ReVanced/revanced-cli"
+    cli_source: str = "MorpheApp/morphe-cli"
     cli_version: str = "latest"
     cli_jar: Path | None = None
     patches_jars: list[Path] = field(default_factory=list)
@@ -743,15 +743,32 @@ class AppProcessor:
             [context.patches_source] if isinstance(context.patches_source, str) else context.patches_source
         )
 
+        from scripts.scrapers.external_bundles import (
+            is_external_bundles_source,
+            parse_bundle_selector,
+            resolve_bundle,
+        )
+
         for idx, patches_src in enumerate(patches_sources):
             patches_jar = prebuilts_dir / f"patches-{context.patches_version}-{idx}.jar"
             patches_jars.append(patches_jar)
 
-            if not patches_jar.exists():
-                patches_url = f"https://github.com/{patches_src}/releases/download/v{context.patches_version}/revanced-patches-{context.patches_version}.jar"
-                success = gh_dl(patches_jar, patches_url)
-                if not success:
-                    raise RuntimeError(f"Failed to download patches from {patches_url}")
+            if patches_jar.exists():
+                continue
+
+            if is_external_bundles_source(patches_src):
+                selector = parse_bundle_selector(patches_src) or context.app_id
+                entry = resolve_bundle(selector, context.patches_version)
+                patches_url = entry.download_url
+            else:
+                patches_url = (
+                    f"https://github.com/{patches_src}/releases/download/v{context.patches_version}/"
+                    f"revanced-patches-{context.patches_version}.jar"
+                )
+
+            success = gh_dl(patches_jar, patches_url)
+            if not success:
+                raise RuntimeError(f"Failed to download patches from {patches_url}")
 
         return cli_jar, patches_jars
 
@@ -1028,7 +1045,7 @@ class GlobalConfig:
     build_mode: str = "apk"
     patches_version: str = "latest"
     cli_version: str = "latest"
-    patches_source: str | list[str] = "ReVanced/revanced-patches"
+    patches_source: str | list[str] = "MorpheApp/morphe-patches"
     riplib: bool = True
     keystore_path: str | None = None
 

--- a/scripts/builder/app_processor.py
+++ b/scripts/builder/app_processor.py
@@ -621,7 +621,7 @@ class AppProcessor:
         patches_source = app_config.patches_source or self.config.global_settings.patches_source
         patches_version = self.config.global_settings.patches_version
 
-        cli_source = self.config.global_settings.patches_source
+        cli_source = app_config.cli_source or self.config.global_settings.cli_source
         cli_version = self.config.global_settings.cli_version
 
         output_dir = Path("build")

--- a/scripts/builder/cli_profiles.py
+++ b/scripts/builder/cli_profiles.py
@@ -205,10 +205,10 @@ MORPHE_CLI = CLIProfile(
 )
 
 ADOBO_CLI = CLIProfile(
-    name="Adobo CLI",
+    name="Adobo (Morphe patches)",
     profile_type=CLIProfileType.ADOBO_CLI,
-    list_patches_args=_v6_list_patches_args(),
-    patch_args=_v6_patch_args(),
+    list_patches_args=_morphe_list_patches_args(),
+    patch_args=_morphe_patch_args(),
 )
 
 BUILTIN_PROFILES: dict[CLIProfileType, CLIProfile] = {
@@ -305,7 +305,7 @@ def build_cli_args(
     bare: bool = False,
     inplace: bool = False,
     werror: bool = False,
-    _options: dict[str, Any] | None = None,
+    options: dict[str, Any] | None = None,  # noqa: ARG001
 ) -> list[str]:
     """Build command arguments from profile configuration.
 

--- a/scripts/builder/cli_profiles.py
+++ b/scripts/builder/cli_profiles.py
@@ -18,6 +18,7 @@ class CLIProfileType(Enum):
     REVANCED_CLI_V5 = "revanced-cli-v5"
     REVANCED_CLI_V6 = "revanced-cli-v6"
     MORPHE_CLI = "morphe-cli"
+    ADOBO_CLI = "adobo-cli"
     UNKNOWN = "unknown"
 
 
@@ -203,10 +204,18 @@ MORPHE_CLI = CLIProfile(
     patch_args=_morphe_patch_args(),
 )
 
+ADOBO_CLI = CLIProfile(
+    name="Adobo CLI",
+    profile_type=CLIProfileType.ADOBO_CLI,
+    list_patches_args=_v6_list_patches_args(),
+    patch_args=_v6_patch_args(),
+)
+
 BUILTIN_PROFILES: dict[CLIProfileType, CLIProfile] = {
     CLIProfileType.REVANCED_CLI_V5: REVANCED_CLI_V5,
     CLIProfileType.REVANCED_CLI_V6: REVANCED_CLI_V6,
     CLIProfileType.MORPHE_CLI: MORPHE_CLI,
+    CLIProfileType.ADOBO_CLI: ADOBO_CLI,
 }
 
 
@@ -260,6 +269,9 @@ def _detect_profile_from_help(help_output: str) -> CLIProfile:
         Detected CLIProfile.
     """
     help_lower = help_output.lower()
+
+    if "adobo" in help_lower:
+        return ADOBO_CLI
 
     if "morphe" in help_lower:
         return MORPHE_CLI

--- a/scripts/builder/config.py
+++ b/scripts/builder/config.py
@@ -44,8 +44,8 @@ class GlobalConfig:
     cli_profile: str = "auto"
     patches_version: str = "latest"
     cli_version: str = "latest"
-    patches_source: str | list[str] = "ReVanced/revanced-patches"
-    cli_source: str = "ReVanced/revanced-cli"
+    patches_source: str | list[str] = "MorpheApp/morphe-patches"
+    cli_source: str = "MorpheApp/morphe-cli"
     riplib: bool = True
     enable_aapt2_optimize: bool = True
     exclusive_load: bool = False

--- a/scripts/builder/config.py
+++ b/scripts/builder/config.py
@@ -45,6 +45,7 @@ class GlobalConfig:
     patches_version: str = "latest"
     cli_version: str = "latest"
     patches_source: str | list[str] = "ReVanced/revanced-patches"
+    cli_source: str = "ReVanced/revanced-cli"
     riplib: bool = True
     enable_aapt2_optimize: bool = True
     exclusive_load: bool = False
@@ -91,6 +92,7 @@ class AppConfig:
     version: str | None = None
     version_code: int | None = None
     patches_source: str | list[str] | None = None
+    cli_source: str | None = None
     patches: list[str] = field(default_factory=list)
     exclude_patches: list[str] = field(default_factory=list)
     merge_patches: list[str] = field(default_factory=list)
@@ -132,6 +134,7 @@ class AppConfig:
             version=data.pop("version", None),
             version_code=data.pop("version_code", None),
             patches_source=data.pop("patches_source", None),
+            cli_source=data.pop("cli_source", None),
             patches=data.pop("patches", []),
             exclude_patches=data.pop("exclude_patches", []),
             merge_patches=data.pop("merge_patches", []),

--- a/scripts/builder/patcher.py
+++ b/scripts/builder/patcher.py
@@ -345,6 +345,11 @@ class ReVancedPatcher:
     ) -> list[str]:
         """Build arguments for the patch command.
 
+        Delegates flag mapping to the active ``CLIProfile`` so the same patcher
+        works across ReVanced CLI v5/v6, Morphe, and Adobo (Morphe-compatible)
+        without branching here. Signing/keystore-password/aapt2 flags are
+        appended afterwards since they have no profile-level mapping yet.
+
         Args:
             stock_apk: Path to the input APK.
             output_apk: Path to the output APK.
@@ -358,31 +363,21 @@ class ReVancedPatcher:
         Returns:
             List of command arguments.
         """
-        args: list[str] = []
-
-        args.append(str(stock_apk))
-        args.append("--purge")
-        args.extend(["-o", str(output_apk)])
-
-        for jar in patches_jars:
-            args.extend(["-p", str(jar)])
-
-        for jar in patches_post:
-            args.extend(["-b", str(jar)])
-
-        for patch_name in exclude_patches:
-            args.extend(["-d", patch_name])
-
-        for patch_name in include_patches:
-            args.extend(["-e", patch_name])
-
-        for jar in merge_jars:
-            args.extend(["-m", str(jar)])
+        args: list[str] = self.cli_profile.build_patch_args(
+            apk_path=stock_apk,
+            output_path=output_apk,
+            patches_jars=patches_jars,
+            patches_post=patches_post,
+            exclude=exclude_patches,
+            include=include_patches,
+            merge=merge_jars,
+            keystore=self.patcher_config.keystore_path,
+            force=force,
+            purge=True,
+        )
 
         args.extend(
             [
-                "--keystore",
-                str(self.patcher_config.keystore_path),
                 "--keystore-password=env:RV_KEYSTORE_PASSWORD",
                 "--keystore-entry-password=env:RV_KEYSTORE_ENTRY_PASSWORD",
                 "--signer",
@@ -391,9 +386,6 @@ class ReVancedPatcher:
                 self.patcher_config.key_alias,
             ]
         )
-
-        if force:
-            args.append("-f")
 
         if self.patcher_config.custom_aapt2_binary and self.patcher_config.custom_aapt2_binary.exists():
             args.append(f"--custom-aapt2-binary={self.patcher_config.custom_aapt2_binary}")

--- a/scripts/scrapers/external_bundles.py
+++ b/scripts/scrapers/external_bundles.py
@@ -1,0 +1,155 @@
+"""External-bundles aggregator client.
+
+Resolves patch-bundle download URLs via the public GraphQL endpoint of
+`brosssh/revanced-external-bundles`, a community-maintained metadata service.
+
+The service does not host JARs itself; bundle entries carry a `download_url`
+that points at the upstream publisher's artifact (typically a GitHub release).
+
+This module is used when `patches-source` in `config.toml` is set to the
+sentinel `brosssh/revanced-external-bundles` (or an explicit URL prefixed with
+`external-bundles:`). For any other value, the regular GitHub release path
+is used by the caller.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+EXTERNAL_BUNDLES_GRAPHQL_URL = "https://revanced-external-bundles.brosssh.com/hasura/v1/graphql"
+EXTERNAL_BUNDLES_REPO_SLUG = "brosssh/revanced-external-bundles"
+EXTERNAL_BUNDLES_URL_PREFIX = "external-bundles:"
+HTTP_TIMEOUT_SECONDS = 20
+
+
+@dataclass(frozen=True)
+class BundleEntry:
+    """Resolved metadata for one external bundle."""
+
+    bundle_type: str
+    version: str
+    download_url: str
+    signature_download_url: str | None = None
+
+
+def is_external_bundles_source(source: str) -> bool:
+    """Return True if ``source`` should be resolved via the external-bundles API."""
+    return source == EXTERNAL_BUNDLES_REPO_SLUG or source.startswith(EXTERNAL_BUNDLES_URL_PREFIX)
+
+
+def parse_bundle_selector(source: str) -> str | None:
+    """Extract the bundle_type selector from an ``external-bundles:<type>`` string.
+
+    Returns None when no selector was given (caller should match by package).
+    """
+    if source.startswith(EXTERNAL_BUNDLES_URL_PREFIX):
+        selector = source[len(EXTERNAL_BUNDLES_URL_PREFIX) :].strip()
+        return selector or None
+    return None
+
+
+def _graphql_query(query: str, variables: dict[str, object] | None = None) -> dict[str, object]:
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310 — fixed https endpoint
+        EXTERNAL_BUNDLES_GRAPHQL_URL,
+        data=payload,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+            body = resp.read().decode("utf-8")
+    except (urllib.error.URLError, TimeoutError) as e:
+        raise RuntimeError(f"external-bundles GraphQL request failed: {e}") from e
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"external-bundles GraphQL returned non-JSON: {e}") from e
+
+    if "errors" in data:
+        raise RuntimeError(f"external-bundles GraphQL errors: {data['errors']}")
+    return data.get("data", {})
+
+
+_BUNDLE_QUERY = """
+query LatestBundle($bundleType: String, $version: String) {
+  bundle(
+    where: {
+      _and: [
+        {bundle_type: {_eq: $bundleType}},
+        {version: {_eq: $version}}
+      ]
+    }
+    order_by: {created_at: desc}
+    limit: 1
+  ) {
+    bundle_type
+    version
+    download_url
+    signature_download_url
+  }
+}
+"""
+
+_LATEST_BY_TYPE_QUERY = """
+query LatestBundleByType($bundleType: String!) {
+  bundle(
+    where: {bundle_type: {_eq: $bundleType}, is_prerelease: {_eq: false}}
+    order_by: {created_at: desc}
+    limit: 1
+  ) {
+    bundle_type
+    version
+    download_url
+    signature_download_url
+  }
+}
+"""
+
+
+def resolve_bundle(bundle_type: str, version: str = "latest") -> BundleEntry:
+    """Look up a bundle by ``bundle_type`` and version (``latest`` for newest stable).
+
+    Args:
+        bundle_type: The aggregator's ``bundle_type`` selector (e.g. ``revanced-patches``).
+        version: Version string or ``"latest"`` to pick the newest non-prerelease.
+
+    Returns:
+        A populated ``BundleEntry``.
+
+    Raises:
+        RuntimeError: When the API call fails or no bundle matches.
+    """
+    if version in {"latest", "dev", ""}:
+        data = _graphql_query(_LATEST_BY_TYPE_QUERY, {"bundleType": bundle_type})
+    else:
+        data = _graphql_query(_BUNDLE_QUERY, {"bundleType": bundle_type, "version": version})
+
+    bundles = data.get("bundle", []) if isinstance(data, dict) else []
+    if not bundles:
+        raise RuntimeError(
+            f"external-bundles: no bundle found for type={bundle_type!r} version={version!r}",
+        )
+
+    entry = bundles[0]
+    if not isinstance(entry, dict):
+        raise TypeError(f"external-bundles: unexpected response shape: {entry!r}")
+
+    download_url = entry.get("download_url")
+    if not isinstance(download_url, str) or not download_url:
+        raise RuntimeError(f"external-bundles: bundle has no download_url: {entry!r}")
+
+    sig = entry.get("signature_download_url")
+    return BundleEntry(
+        bundle_type=str(entry.get("bundle_type", bundle_type)),
+        version=str(entry.get("version", version)),
+        download_url=download_url,
+        signature_download_url=sig if isinstance(sig, str) and sig else None,
+    )

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -1,0 +1,36 @@
+"""Tests for scripts/builder/cli_profiles.py."""
+
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+from scripts.builder.cli_profiles import (
+    ADOBO_CLI,
+    BUILTIN_PROFILES,
+    MORPHE_CLI,
+    REVANCED_CLI_V5,
+    REVANCED_CLI_V6,
+    CLIProfileType,
+    _detect_profile_from_help,
+)
+
+
+def test_builtin_profiles_include_adobo() -> None:
+    assert CLIProfileType.ADOBO_CLI in BUILTIN_PROFILES
+    assert BUILTIN_PROFILES[CLIProfileType.ADOBO_CLI] is ADOBO_CLI
+
+
+def test_detect_adobo_profile_from_help() -> None:
+    assert _detect_profile_from_help("Adobo CLI usage: ...") is ADOBO_CLI
+
+
+def test_detect_morphe_profile_from_help() -> None:
+    assert _detect_profile_from_help("Morphe CLI usage: ...") is MORPHE_CLI
+
+
+def test_detect_v6_profile_from_help() -> None:
+    assert _detect_profile_from_help("-b --patch-bundle <bundle>") is REVANCED_CLI_V6
+
+
+def test_detect_v5_profile_default() -> None:
+    assert _detect_profile_from_help("nothing helpful here") is REVANCED_CLI_V5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,10 @@ class TestGlobalConfig:
         assert cfg.verbose is True
 
     def test_default_cli_source(self) -> None:
-        assert GlobalConfig().cli_source == "ReVanced/revanced-cli"
+        assert GlobalConfig().cli_source == "MorpheApp/morphe-cli"
+
+    def test_default_patches_source(self) -> None:
+        assert GlobalConfig().patches_source == "MorpheApp/morphe-patches"
 
     def test_cli_source_override(self) -> None:
         cfg = GlobalConfig.from_dict({"cli_source": "MorpheApp/morphe-cli"})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,13 @@ class TestGlobalConfig:
         assert cfg.riplib is False
         assert cfg.verbose is True
 
+    def test_default_cli_source(self) -> None:
+        assert GlobalConfig().cli_source == "ReVanced/revanced-cli"
+
+    def test_cli_source_override(self) -> None:
+        cfg = GlobalConfig.from_dict({"cli_source": "MorpheApp/morphe-cli"})
+        assert cfg.cli_source == "MorpheApp/morphe-cli"
+
 
 # ---------------------------------------------------------------------------
 # AppConfig.from_dict
@@ -88,6 +95,17 @@ class TestAppConfigFromDict:
     def test_invalid_name_type_raises(self) -> None:
         with pytest.raises(ConfigError):
             AppConfig.from_dict(123, {})  # type: ignore[arg-type]
+
+    def test_cli_source_default(self) -> None:
+        assert AppConfig.from_dict("YouTube", {}).cli_source is None
+
+    def test_cli_source_override(self) -> None:
+        cfg = AppConfig.from_dict("YouTube", {"cli_source": "MorpheApp/morphe-cli"})
+        assert cfg.cli_source == "MorpheApp/morphe-cli"
+
+    def test_cli_source_not_in_options(self) -> None:
+        cfg = AppConfig.from_dict("YouTube", {"cli_source": "MorpheApp/morphe-cli"})
+        assert "cli_source" not in cfg.options
 
 
 # ---------------------------------------------------------------------------
@@ -202,7 +220,9 @@ class TestConfigLoader:
 
 
 class TestConfig:
-    def _make_config(self, apps: dict[str, AppConfig], modules: dict[str, dict[str, ModuleConfig]] | None = None) -> Config:
+    def _make_config(
+        self, apps: dict[str, AppConfig], modules: dict[str, dict[str, ModuleConfig]] | None = None
+    ) -> Config:
         return Config(
             global_settings=GlobalConfig(),
             apps=apps,

--- a/tests/test_external_bundles.py
+++ b/tests/test_external_bundles.py
@@ -1,0 +1,90 @@
+"""Tests for scripts/scrapers/external_bundles.py."""
+
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from scripts.scrapers.external_bundles import (
+    BundleEntry,
+    is_external_bundles_source,
+    parse_bundle_selector,
+    resolve_bundle,
+)
+
+
+class TestSourceDetection:
+    def test_repo_slug_recognized(self) -> None:
+        assert is_external_bundles_source("brosssh/revanced-external-bundles") is True
+
+    def test_prefixed_form_recognized(self) -> None:
+        assert is_external_bundles_source("external-bundles:revanced-patches") is True
+
+    def test_other_sources_not_recognized(self) -> None:
+        assert is_external_bundles_source("MorpheApp/morphe-patches") is False
+        assert is_external_bundles_source("anddea/revanced-patches") is False
+
+    def test_parse_selector_returns_none_for_repo_slug(self) -> None:
+        assert parse_bundle_selector("brosssh/revanced-external-bundles") is None
+
+    def test_parse_selector_extracts_bundle_type(self) -> None:
+        assert parse_bundle_selector("external-bundles:revanced-patches") == "revanced-patches"
+
+    def test_parse_selector_empty_returns_none(self) -> None:
+        assert parse_bundle_selector("external-bundles:") is None
+
+
+class TestResolveBundle:
+    def test_returns_bundle_entry_from_graphql(self) -> None:
+        fake = {
+            "bundle": [
+                {
+                    "bundle_type": "revanced-patches",
+                    "version": "5.0.0",
+                    "download_url": "https://example.com/patches.jar",
+                    "signature_download_url": "https://example.com/patches.jar.asc",
+                },
+            ],
+        }
+        with patch("scripts.scrapers.external_bundles._graphql_query", return_value=fake):
+            entry = resolve_bundle("revanced-patches", "latest")
+        assert isinstance(entry, BundleEntry)
+        assert entry.version == "5.0.0"
+        assert entry.download_url == "https://example.com/patches.jar"
+        assert entry.signature_download_url == "https://example.com/patches.jar.asc"
+
+    def test_specific_version_query(self) -> None:
+        fake = {
+            "bundle": [
+                {
+                    "bundle_type": "revanced-patches",
+                    "version": "4.2.0",
+                    "download_url": "https://example.com/patches.jar",
+                    "signature_download_url": None,
+                },
+            ],
+        }
+        with patch("scripts.scrapers.external_bundles._graphql_query", return_value=fake) as mock:
+            entry = resolve_bundle("revanced-patches", "4.2.0")
+        assert entry.version == "4.2.0"
+        assert entry.signature_download_url is None
+        _, variables = mock.call_args.args
+        assert variables == {"bundleType": "revanced-patches", "version": "4.2.0"}
+
+    def test_missing_bundle_raises(self) -> None:
+        with (
+            patch("scripts.scrapers.external_bundles._graphql_query", return_value={"bundle": []}),
+            pytest.raises(RuntimeError, match="no bundle found"),
+        ):
+            resolve_bundle("revanced-patches", "latest")
+
+    def test_missing_download_url_raises(self) -> None:
+        fake = {"bundle": [{"bundle_type": "x", "version": "1", "download_url": None}]}
+        with (
+            patch("scripts.scrapers.external_bundles._graphql_query", return_value=fake),
+            pytest.raises(RuntimeError, match="no download_url"),
+        ):
+            resolve_bundle("x", "latest")

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scripts.builder.cli_profiles import CLIProfile
+from scripts.builder.cli_profiles import (
+    ADOBO_CLI,
+    MORPHE_CLI,
+    REVANCED_CLI_V5,
+    REVANCED_CLI_V6,
+    CLIProfile,
+)
 from scripts.builder.config import AppConfig
 from scripts.builder.patcher import (
     CacheManager,
@@ -86,3 +92,87 @@ def test_get_cached_patches_list_read_text_success(patcher: ReVancedPatcher, tmp
 
         assert result == "cached patches"
         mock_run.assert_not_called()
+
+
+def _make_patcher(tmp_path: Path, profile: CLIProfile) -> ReVancedPatcher:
+    java_runner_mock = MagicMock(spec=JavaRunner)
+    java_runner_mock.java_args = ["-Xmx2G"]
+    patcher_config = PatcherConfig(
+        keystore_path=tmp_path / "ks.jks",
+        keystore_password="pw",  # noqa: S106
+        key_alias="alias",
+        key_password="pw",  # noqa: S106
+    )
+    return ReVancedPatcher(
+        config=MagicMock(spec=AppConfig),
+        cli_profile=profile,
+        java_runner=java_runner_mock,
+        patcher_config=patcher_config,
+        cache_manager=CacheManager(cache_dir=tmp_path / "cache"),
+    )
+
+
+@pytest.mark.parametrize("profile", [REVANCED_CLI_V5, REVANCED_CLI_V6, MORPHE_CLI, ADOBO_CLI])
+def test_build_patch_args_delegates_to_profile(profile: CLIProfile, tmp_path: Path) -> None:
+    """_build_patch_args should produce profile-appropriate flags plus signing extras."""
+    p = _make_patcher(tmp_path, profile)
+    stock = tmp_path / "in.apk"
+    out = tmp_path / "out.apk"
+    pjar = tmp_path / "patches.jar"
+
+    args = p._build_patch_args(
+        stock_apk=stock,
+        output_apk=out,
+        patches_jars=[pjar],
+        exclude_patches=["X"],
+        include_patches=["Y"],
+        merge_jars=[],
+        patches_post=[],
+        force=True,
+    )
+
+    # Profile-driven content: input, output, patches jar, exclude, include all appear.
+    assert str(stock) in args
+    assert str(out) in args
+    assert str(pjar) in args
+    assert "X" in args
+    assert "Y" in args
+    # Signing extras are always appended regardless of profile.
+    assert "--keystore-password=env:RV_KEYSTORE_PASSWORD" in args
+    assert "--keystore-entry-password=env:RV_KEYSTORE_ENTRY_PASSWORD" in args
+    assert "--signer" in args
+    assert "alias" in args
+    assert "--keystore-entry-alias" in args
+
+
+def test_build_patch_args_v6_uses_short_flags(tmp_path: Path) -> None:
+    p = _make_patcher(tmp_path, REVANCED_CLI_V6)
+    args = p._build_patch_args(
+        stock_apk=tmp_path / "in.apk",
+        output_apk=tmp_path / "out.apk",
+        patches_jars=[tmp_path / "p.jar"],
+        exclude_patches=[],
+        include_patches=[],
+        merge_jars=[],
+        patches_post=[],
+        force=False,
+    )
+    assert "-i" in args
+    assert "-o" in args
+
+
+def test_build_patch_args_morphe_uses_long_flags(tmp_path: Path) -> None:
+    p = _make_patcher(tmp_path, MORPHE_CLI)
+    args = p._build_patch_args(
+        stock_apk=tmp_path / "in.apk",
+        output_apk=tmp_path / "out.apk",
+        patches_jars=[tmp_path / "p.jar"],
+        exclude_patches=[],
+        include_patches=[],
+        merge_jars=[],
+        patches_post=[],
+        force=False,
+    )
+    assert "--input" in args
+    assert "--output" in args
+    assert "--purge" in args


### PR DESCRIPTION
## Summary
This PR adds support for the `brosssh/revanced-external-bundles` aggregator as a patches source, introduces Adobo CLI profile support (Morphe-compatible), and switches the default patcher to Morphe (from ReVanced). It also refactors patch argument building to delegate to CLI profiles for better multi-CLI compatibility.

## Key Changes

### External Bundles Aggregator Support
- **New module** `scripts/scrapers/external_bundles.py`: GraphQL client for resolving patch-bundle metadata from the external-bundles service
  - `resolve_bundle()` queries by bundle type and version (supports "latest" for stable releases)
  - `is_external_bundles_source()` and `parse_bundle_selector()` helpers for source detection
  - Handles both repo-slug form (`brosssh/revanced-external-bundles`) and explicit selector form (`external-bundles:revanced-patches`)
  - Comprehensive error handling for API failures and missing bundles
- **Integration** in `scripts/builder/app_processor.py`: patches download logic now checks for external-bundles sources and resolves via GraphQL before falling back to GitHub releases
- **Tests** in `tests/test_external_bundles.py`: source detection, selector parsing, and bundle resolution with mocked GraphQL responses

### CLI Profile Enhancements
- **New profile** `ADOBO_CLI` in `scripts/builder/cli_profiles.py`: Adobo (Morphe-compatible patches) with identical flag mapping to Morphe
  - Added `CLIProfileType.ADOBO_CLI` enum variant
  - Profile detection updated to recognize "adobo" in help output
- **Refactored patch args** in `scripts/builder/patcher.py`: `_build_patch_args()` now delegates to `cli_profile.build_patch_args()` instead of hardcoding flags
  - Signing/keystore flags appended after profile-driven args for consistency across all CLI variants
  - Improves maintainability for future CLI versions

### Default Configuration Changes
- **Global defaults** in `scripts/builder/config.py` and `config.toml`:
  - `patches_source` changed from `ReVanced/revanced-patches` to `MorpheApp/morphe-patches`
  - New `cli_source` field defaults to `MorpheApp/morphe-cli`
- **Sample config** in `config.toml`: YouTube/Music Extended (RVX) sections disabled by default; Morphe sections enabled
- **Documentation** updated in `README.md` and `docs/CONFIG.md` to reflect Morphe as primary default with examples for ReVanced, RVX, and external-bundles alternatives

### Build Environment Improvements
- **GitHub Actions** (`.github/workflows/build-pr.yml`, `.github/actions/setup-environment/action.yml`):
  - Replaced separate `setup-java` and `setup-uv` with unified `jdx/mise-action` for tool management
  - Simplified Python version handling via `mise.toml`
- **New workflow** `.github/workflows/pages.yml`: Jekyll-based documentation deployment to GitHub Pages
- **Python version** in `mise.toml` pinned to 3.13 (from 3.14)

### Testing
- **New test file** `tests/test_cli_profiles.py`: validates profile detection and builtin profile registry
- **Extended tests** in `tests/test_patcher.py`: added `_make_patcher()` helper and parametrized tests for `_build_patch_args()` across all CLI profiles (v5, v6, Morphe, Adobo)
- **Config tests** in `tests/test_config.py`: new assertions for `cli_source` defaults and overrides

## Implementation Details
- External bundles GraphQL queries use parameterized variables for type/version filtering; "latest" queries exclude pre-releases
- Bundle selector parsing strips whitespace and returns `None` for empty selectors (falls back to package ID matching)
- CLI profile delegation preserves all existing signing/keystore behavior while centralizing flag mapping
-

https://claude.ai/code/session_01HQ3AEZvRey2YdzzsMrNEde