### PR TITLE
🔒 [security fix] Path Traversal in Zip Extraction

### DIFF
--- a/scripts/utils/apk.py
+++ b/scripts/utils/apk.py
@@ -389,6 +389,8 @@ class SplitAPKHandler:
             with zipfile.ZipFile(bundle_path, "r") as zf:
                 for name in zf.namelist():
                     if name.endswith(".apk"):
+                        if not _validate_path(output_dir / name, output_dir):
+                            continue
                         dest = output_dir / Path(name).name
                         zf.extract(name, output_dir)
                         extracted = output_dir / name

--- a/tests/test_apk.py
+++ b/tests/test_apk.py
@@ -147,6 +147,28 @@ class TestSplitAPKHandler:
             jar = handler._find_apkeditor()
         assert jar is None
 
+    def test_extract_splits_skips_malicious_paths(self, tmp_path: Path) -> None:
+        # ruff: noqa: PLC0415
+        import zipfile
+
+        bundle = tmp_path / "malicious.xapk"
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        with zipfile.ZipFile(bundle, "w") as zf:
+            # zipfile.ZipInfo objects can have absolute or traversal paths
+            info = zipfile.ZipInfo("../evil.apk")
+            zf.writestr(info, b"evil content")
+            zf.writestr("good.apk", b"good content")
+
+        handler = SplitAPKHandler()
+        splits = handler.extract_splits(bundle, out_dir)
+
+        # Should only contain good.apk, evil.apk should be skipped
+        assert len(splits) == 1
+        assert splits[0].name == "good.apk"
+        assert not (tmp_path / "evil.apk").exists()
+
 
 # ---------------------------------------------------------------------------
 # AAPT2Manager


### PR DESCRIPTION
🎯 **What:** Fixed a Path Traversal (Zip Slip) vulnerability in the `extract_splits` method of `SplitAPKHandler`.
⚠️ **Risk:** A malicious XAPK or APKM bundle could contain files with traversal sequences (e.g., `../../evil.apk`) that, when extracted, could overwrite arbitrary files outside the intended output directory.
🛡️ **Solution:** Added a call to the existing `_validate_path` helper function to ensure each ZIP member resolves to a location within the target output directory before proceeding with extraction.

---
*PR created automatically by Jules for task [13596464191934864528](https://jules.google.com/task/13596464191934864528) started by @Ven0m0*