### PR TITLE
🧹 [code health] Remove unused ApkBundle Enum from apkmirror scraper

### DIFF
--- a/scripts/scrapers/apkmirror.py
+++ b/scripts/scrapers/apkmirror.py
@@ -6,7 +6,6 @@ import asyncio
 import re
 import subprocess
 from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 from typing import Literal
 
@@ -21,13 +20,6 @@ from scripts.scrapers.base import (
 
 type ArchType = Literal["universal", "noarch", "arm64-v8a", "armeabi-v7a", "arm64-v8a + armeabi-v7a"]
 type BundleType = Literal["APK", "BUNDLE"]
-
-
-class ApkBundle(Enum):
-    """APK bundle type."""
-
-    APK = "APK"
-    BUNDLE = "BUNDLE"
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
🎯 **What:** Removed the unused `ApkBundle` Enum and the `Enum` import from `scripts/scrapers/apkmirror.py`.
💡 **Why:** The Enum was a completely unreferenced construct in the codebase, introducing unnecessary clutter. Removing dead code improves the overall maintainability and readability of the application.
✅ **Verification:**
* Performed a codebase-wide search (`grep -rn "ApkBundle"`) which confirmed 0 references outside its definition.
* Verified that `Enum` import is not used elsewhere in `scripts/scrapers/apkmirror.py`.
* Executed formatting, linting (`uv run ruff check`), and the complete unit testing suite (`uv run pytest`), ensuring functionality remains intact.
✨ **Result:** A cleaner `apkmirror` scraper module without unused enums.

---
*PR created automatically by Jules for task [7016252807500395782](https://jules.google.com/task/7016252807500395782) started by @Ven0m0*