### PR TITLE
🧪 Add unit tests for Builder wrapper class

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,58 @@
+"""Tests for the Builder wrapper class."""
+
+# ruff: noqa: S101
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.lib.builder import Builder
+from scripts.lib.config import Config
+
+
+@pytest.fixture
+def mock_config() -> MagicMock:
+    """Provide a mocked Config instance."""
+    config = MagicMock(spec=Config)
+    config.config_file = "test_config.toml"
+    return config
+
+
+def test_builder_init(mock_config: MagicMock) -> None:
+    """Test Builder initialization."""
+    builder = Builder(mock_config)
+    assert builder.config == mock_config
+
+
+@patch("scripts.lib.builder.subprocess.run")
+def test_builder_build_all_success(mock_run: MagicMock, mock_config: MagicMock) -> None:
+    """Test build_all returns True when subprocess succeeds."""
+    mock_run.return_value = MagicMock(returncode=0)
+    builder = Builder(mock_config)
+
+    result = builder.build_all()
+
+    assert result is True
+    mock_run.assert_called_once_with(
+        ["./build.sh", "test_config.toml"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+@patch("scripts.lib.builder.subprocess.run")
+def test_builder_build_all_failure(mock_run: MagicMock, mock_config: MagicMock) -> None:
+    """Test build_all returns False when subprocess fails."""
+    mock_run.return_value = MagicMock(returncode=1)
+    builder = Builder(mock_config)
+
+    result = builder.build_all()
+
+    assert result is False
+    mock_run.assert_called_once_with(
+        ["./build.sh", "test_config.toml"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `Builder` class in `scripts/lib/builder.py` was completely lacking unit tests for its `__init__` configuration assignment and its primary method, `build_all()`, which encapsulates `subprocess.run` to trigger the legacy `build.sh` script.

📊 **Coverage:** What scenarios are now tested
- Initialization (`__init__`) correctly maps the given configuration model to the instance.
- The success branch of `build_all()` returns `True` when `subprocess.run` yields a `returncode` of `0`.
- The failure branch of `build_all()` returns `False` when `subprocess.run` yields a non-zero `returncode` (tested with `1`).
- Asserts that `subprocess.run` is called precisely with `["./build.sh", "test_config.toml"]` and the correct keyword arguments (`capture_output=True`, `check=False`, `text=True`).

✨ **Result:** The improvement in test coverage
`tests/test_builder.py` adds focused tests spanning every logical path in `scripts/lib/builder.py`, safely isolating the test harness from actual shell executions by explicitly mocking `subprocess.run`. Test coverage for the `Builder` class logic is now 100%.

---
*PR created automatically by Jules for task [13724830895357825333](https://jules.google.com/task/13724830895357825333) started by @Ven0m0*