### PR TITLE
🧪 Add tests for AppProcessor._parse_architecture

### DIFF
--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -598,6 +598,7 @@ async def async_download_with_lock(
 
     def _release_lock(fileno: int) -> None:
         import contextlib
+
         fcntl.flock(fileno, fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
             os.close(fileno)

--- a/tests/test_app_processor.py
+++ b/tests/test_app_processor.py
@@ -1,0 +1,40 @@
+"""Tests for AppProcessor."""
+
+# ruff: noqa: S101
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.builder.app_processor import AppProcessor, Architecture
+from scripts.builder.config import AppConfig, GlobalConfig
+
+
+class TestAppProcessor:
+    """Test suite for AppProcessor class."""
+
+    def test_parse_architecture(self) -> None:
+        """Test _parse_architecture handles all valid arch options and defaults correctly."""
+        global_config = GlobalConfig()
+        java_runner = MagicMock()
+        processor = AppProcessor(global_config, java_runner)
+
+        # Test default (no arch specified)
+        config_default = AppConfig(name="TestApp", options={})
+        assert processor._parse_architecture(config_default) == Architecture.ALL
+
+        # Test explicit architectures
+        valid_archs = [
+            ("arm64-v8a", Architecture.ARM64_V8A),
+            ("arm-v7a", Architecture.ARM_V7A),
+            ("both", Architecture.BOTH),
+            ("all", Architecture.ALL),
+        ]
+
+        for arch_str, expected_arch in valid_archs:
+            config = AppConfig(name="TestApp", options={"arch": arch_str})
+            assert processor._parse_architecture(config) == expected_arch
+
+        # Test invalid architecture
+        config_invalid = AppConfig(name="TestApp", options={"arch": "invalid-arch"})
+        with pytest.raises(ValueError, match="Invalid architecture: invalid-arch"):
+            processor._parse_architecture(config_invalid)


### PR DESCRIPTION
🎯 **What:** Added unit testing for the `_parse_architecture` method in `AppProcessor` to fill a testing gap for this component.
📊 **Coverage:** Tests cover the default behavior (fallback to ALL), parsing of valid explicit architecture strings ('arm64-v8a', 'arm-v7a', 'both', 'all'), and proper raising of ValueError for invalid architecture strings.
✨ **Result:** Improved confidence when modifying the `AppConfig` interpretation and validation logic in `AppProcessor`.

---
*PR created automatically by Jules for task [12325000305342942180](https://jules.google.com/task/12325000305342942180) started by @Ven0m0*