### PR TITLE
🔒 Prevent GitHub token exposure in network config logs

### DIFF
--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -46,7 +46,7 @@ class HttpClientConfig:
     initial_delay: int = DEFAULT_INITIAL_DELAY
     connect_timeout: int = 10
     user_agent: str = "Mozilla/5.0 (X11; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0"
-    github_token: str | None = field(default_factory=lambda: os.environ.get("GITHUB_TOKEN"))
+    github_token: str | None = field(default_factory=lambda: os.environ.get("GITHUB_TOKEN"), repr=False)
     cookie_file: Path | None = None
 
 

--- a/tests/test_network_security.py
+++ b/tests/test_network_security.py
@@ -1,0 +1,19 @@
+"""Tests for security aspects of scripts/utils/network.py."""
+
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from scripts.utils.network import HttpClientConfig
+
+
+def test_http_client_config_repr_hides_github_token() -> None:
+    """Test that HttpClientConfig.__repr__ does not expose the GitHub token."""
+    with patch.dict(os.environ, {"GITHUB_TOKEN": "secret_token_12345"}):
+        config = HttpClientConfig()
+        config_repr = repr(config)
+        assert "github_token" not in config_repr
+        assert "secret_token_12345" not in config_repr


### PR DESCRIPTION
🎯 **What:** The `github_token` field in `HttpClientConfig` was implicitly included in the dataclass's auto-generated `__repr__` output.
⚠️ **Risk:** If an `HttpClientConfig` instance was ever printed or logged (e.g., during an exception), the plain text GitHub token would be exposed in the logs.
🛡️ **Solution:** Added `repr=False` to the `github_token` dataclass field definition to securely exclude it from object string representations. Added a unit test to verify this exclusion.

---
*PR created automatically by Jules for task [4363003705828664122](https://jules.google.com/task/4363003705828664122) started by @Ven0m0*