### PR TITLE
🧹 [code health] Remove unused merge_bundle function

### DIFF
--- a/scripts/utils/apk.py
+++ b/scripts/utils/apk.py
@@ -3,7 +3,6 @@
 import re
 import shutil
 import subprocess
-import tempfile
 import zipfile
 from enum import Enum
 from pathlib import Path
@@ -164,62 +163,6 @@ def align_apk(input_path: Path, output_path: Path) -> bool:
         return True
     except subprocess.CalledProcessError:
         return False
-
-
-def merge_bundle(bundle_path: Path, output_path: Path) -> bool:
-    """Merge split APK bundle into single APK using APKEditor.
-
-    Args:
-        bundle_path: Path to the XAPK/APKM bundle file.
-        output_path: Path to the output merged APK file.
-
-    Returns:
-        True if merge succeeded, False otherwise.
-    """
-    if not isinstance(bundle_path, Path):
-        raise ValueError("merge_bundle: bundle_path must be a Path object")
-    if not _validate_path(bundle_path):
-        raise ValueError(f"merge_bundle: path traversal detected in '{bundle_path}'")
-
-    bundle_ext = bundle_path.suffix.lower()
-    if bundle_ext not in (".xapk", ".apkm"):
-        raise ValueError(f"merge_bundle: bundle must be .xapk or .apkm, got '{bundle_ext}'")
-
-    if not _validate_path(output_path):
-        raise ValueError(f"merge_bundle: path traversal detected in '{output_path}'")
-    if output_path.suffix.lower() != ".apk":
-        raise ValueError("merge_bundle: output must have .apk extension")
-
-    if not bundle_path.exists():
-        return False
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-
-        try:
-            cmd = [
-                "java",
-                "-jar",
-                "APKEditor.jar",
-                "merge",
-                "-i",
-                str(bundle_path),
-                "-o",
-                str(temp_path / "merged.apk"),
-            ]
-            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-            if result.returncode != 0:
-                return False
-
-            merged_apk = temp_path / "merged.apk"
-            if not merged_apk.exists():
-                return False
-
-            shutil.copy2(merged_apk, output_path)
-            return True
-
-        except (subprocess.CalledProcessError, OSError):
-            return False
 
 
 def verify_signature(apk_path: Path) -> str | None:

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -598,6 +598,7 @@ async def async_download_with_lock(
 
     def _release_lock(fileno: int) -> None:
         import contextlib
+
         fcntl.flock(fileno, fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
             os.close(fileno)

--- a/tests/test_apk.py
+++ b/tests/test_apk.py
@@ -17,7 +17,6 @@ from scripts.utils.apk import (
     _validate_path,
     align_apk,
     detect_bundle_type,
-    merge_bundle,
 )
 
 # ---------------------------------------------------------------------------
@@ -279,93 +278,3 @@ class TestAlignApk:
         output_path = tmp_path / "output.apk"
         with pytest.raises(ValueError, match="align_apk input: file must have .apk extension"):
             align_apk(input_path, output_path)
-
-
-# ---------------------------------------------------------------------------
-# merge_bundle
-# ---------------------------------------------------------------------------
-
-
-class TestMergeBundle:
-    def test_rejects_non_path_bundle(self) -> None:
-        with pytest.raises(ValueError, match="bundle_path must be a Path object"):
-            merge_bundle("app.xapk", Path("out.apk"))  # type: ignore[arg-type]
-
-    def test_rejects_path_traversal_bundle(self, tmp_path: Path) -> None:
-        bundle_path = Path("/tmp/\x00bad.xapk")
-        with pytest.raises(ValueError, match="path traversal detected"):
-            merge_bundle(bundle_path, tmp_path / "out.apk")
-
-    def test_rejects_invalid_bundle_extension(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.zip"
-        with pytest.raises(ValueError, match="bundle must be .xapk or .apkm"):
-            merge_bundle(bundle_path, tmp_path / "out.apk")
-
-    def test_rejects_path_traversal_output(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        output_path = Path("/tmp/\x00bad.apk")
-        with pytest.raises(ValueError, match="path traversal detected"):
-            merge_bundle(bundle_path, output_path)
-
-    def test_rejects_invalid_output_extension(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        output_path = tmp_path / "out.zip"
-        with pytest.raises(ValueError, match="output must have .apk extension"):
-            merge_bundle(bundle_path, output_path)
-
-    def test_missing_bundle_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        output_path = tmp_path / "out.apk"
-        assert merge_bundle(bundle_path, output_path) is False
-
-    def test_subprocess_called_process_error_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy")
-        output_path = tmp_path / "out.apk"
-        with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "cmd")):
-            assert merge_bundle(bundle_path, output_path) is False
-
-    def test_subprocess_os_error_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy")
-        output_path = tmp_path / "out.apk"
-        with patch("subprocess.run", side_effect=OSError("Permission denied")):
-            assert merge_bundle(bundle_path, output_path) is False
-
-    def test_subprocess_non_zero_returncode_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy")
-        output_path = tmp_path / "out.apk"
-        mock_result = MagicMock()
-        mock_result.returncode = 1
-        with patch("subprocess.run", return_value=mock_result):
-            assert merge_bundle(bundle_path, output_path) is False
-
-    def test_missing_merged_apk_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy")
-        output_path = tmp_path / "out.apk"
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        with patch("subprocess.run", return_value=mock_result):
-            assert merge_bundle(bundle_path, output_path) is False
-
-    def test_success(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy bundle")
-        output_path = tmp_path / "out.apk"
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-
-        def mock_run_side_effect(*args: object, **kwargs: object) -> MagicMock:
-            cmd = args[0]
-            assert isinstance(cmd, list)
-            merged_apk_path = Path(cmd[-1])
-            merged_apk_path.write_bytes(b"merged apk content")
-            return mock_result
-
-        with patch("subprocess.run", side_effect=mock_run_side_effect):
-            assert merge_bundle(bundle_path, output_path) is True
-
-        assert output_path.exists()
-        assert output_path.read_bytes() == b"merged apk content"


### PR DESCRIPTION
🎯 **What:** Removed the unused `merge_bundle` function from `scripts/utils/apk.py` and its corresponding tests in `tests/test_apk.py`.
💡 **Why:** `merge_bundle` was dead code. Removing it reduces maintenance overhead and improves readability of `apk.py`.
✅ **Verification:** Verified by grepping for `merge_bundle` to ensure it is unused in the codebase. Ran the full `uv run pytest` suite and it passed (222 tests), proving that removing it did not break any functionality. Ran linters to ensure code style is retained.
✨ **Result:** A cleaner codebase with less dead code and unnecessary test maintenance.

---
*PR created automatically by Jules for task [1704824893309288364](https://jules.google.com/task/1704824893309288364) started by @Ven0m0*