### PR TITLE
🧪 Add tests for AppProcessor._determine_download_source

### DIFF
--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -598,6 +598,7 @@ async def async_download_with_lock(
 
     def _release_lock(fileno: int) -> None:
         import contextlib
+
         fcntl.flock(fileno, fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
             os.close(fileno)

--- a/tests/test_app_processor.py
+++ b/tests/test_app_processor.py
@@ -1,0 +1,49 @@
+"""Tests for scripts/builder/app_processor.py."""
+
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.builder.app_processor import AppProcessor, DownloadSource
+from scripts.builder.config import AppConfig
+
+
+class TestAppProcessor:
+    @pytest.fixture
+    def app_processor(self) -> AppProcessor:
+        """Provide a mocked AppProcessor instance."""
+        config_mock = MagicMock()
+        java_runner_mock = MagicMock()
+        return AppProcessor(config=config_mock, java_runner=java_runner_mock)
+
+    @pytest.mark.parametrize(
+        ("options", "expected_source"),
+        [
+            ({"apkmirror_dlurl": "https://apkmirror.com/some/path"}, DownloadSource.APKMIRROR),
+            ({"uptodown_dlurl": "https://uptodown.com/some/path"}, DownloadSource.UPTODOWN),
+            ({"apkpure_dlurl": "https://apkpure.com/some/path"}, DownloadSource.APKPURE),
+            ({"archive_dlurl": "https://archive.org/some/path"}, DownloadSource.ARCHIVE),
+            ({"aptoide_dlurl": "https://aptoide.com/some/path"}, DownloadSource.APTOIDE),
+            ({"apkmonk_dlurl": "https://apkmonk.com/some/path"}, DownloadSource.APKMonk),
+            ({}, DownloadSource.APKMIRROR),
+            ({"other_dlurl": "https://example.com/"}, DownloadSource.APKMIRROR),
+        ],
+    )
+    def test_determine_download_source(
+        self,
+        app_processor: AppProcessor,
+        options: dict[str, str],
+        expected_source: DownloadSource,
+    ) -> None:
+        """Test download source resolution based on app configuration."""
+        app_config = AppConfig(name="TestApp", options=options)
+
+        # We need to call the private method for this specific test
+        # pylint: disable=protected-access
+        source = app_processor._determine_download_source(app_config)
+
+        assert source == expected_source


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested deterministic function that evaluated a configuration dictionary (`options`) to return a `DownloadSource` Enum in the `AppProcessor` module.
📊 **Coverage:** Scenarios that are now fully tested include all explicitly mapped download sources (APKMirror, Uptodown, APKPure, Archive, Aptoide, and APKMonk) and a default fallback case for unrecognized options.
✨ **Result:** Test coverage for `AppProcessor._determine_download_source` is established guaranteeing any future configuration overrides won't accidentally break generation of internal download URLs.

---
*PR created automatically by Jules for task [9594135387567379330](https://jules.google.com/task/9594135387567379330) started by @Ven0m0*