### PR TITLE
🧹 Refactor `patch` method in `ReVancedPatcher` to reduce complexity

### DIFF
--- a/scripts/builder/patcher.py
+++ b/scripts/builder/patcher.py
@@ -232,24 +232,14 @@ class ReVancedPatcher:
         Returns:
             PatcherResult indicating success or failure.
         """
-        if not stock_apk.exists():
-            return PatcherResult(success=False, error=f"Stock APK not found: {stock_apk}")
+        error = self._verify_inputs(stock_apk, cli_jar, patches_jars)
+        if error:
+            return PatcherResult(success=False, error=error)
 
-        if not cli_jar.exists():
-            return PatcherResult(success=False, error=f"CLI JAR not found: {cli_jar}")
-
-        for jar in patches_jars:
-            if not jar.exists():
-                return PatcherResult(success=False, error=f"Patches JAR not found: {jar}")
-
-        if exclude_patches is None:
-            exclude_patches = []
-        if include_patches is None:
-            include_patches = []
-        if merge_jars is None:
-            merge_jars = []
-        if patches_post is None:
-            patches_post = []
+        exclude_patches = exclude_patches or []
+        include_patches = include_patches or []
+        merge_jars = merge_jars or []
+        patches_post = patches_post or []
 
         output_apk.parent.mkdir(parents=True, exist_ok=True)
 
@@ -268,6 +258,37 @@ class ReVancedPatcher:
             force=force,
         )
 
+        result = self._execute_patch_command(cli_jar, cli_args)
+        if result:
+            return result
+
+        if not output_apk.exists():
+            return PatcherResult(success=False, error="Patching succeeded but output APK not found")
+
+        result = self._sign_apk(output_apk)
+        if result:
+            return result
+
+        self._zipalign_apk(output_apk)
+
+        return PatcherResult(success=True, output_apk=output_apk, version=version)
+
+    def _verify_inputs(self, stock_apk: Path, cli_jar: Path, patches_jars: list[Path]) -> str | None:
+        """Verify that all input files exist."""
+        if not stock_apk.exists():
+            return f"Stock APK not found: {stock_apk}"
+
+        if not cli_jar.exists():
+            return f"CLI JAR not found: {cli_jar}"
+
+        for jar in patches_jars:
+            if not jar.exists():
+                return f"Patches JAR not found: {jar}"
+
+        return None
+
+    def _execute_patch_command(self, cli_jar: Path, cli_args: list[str]) -> PatcherResult | None:
+        """Execute the ReVanced CLI patch command."""
         logger.info("Executing: java -jar %s patch %s", cli_jar.name, " ".join(cli_args))
 
         env = os.environ.copy()
@@ -301,9 +322,10 @@ class ReVancedPatcher:
         except OSError as e:
             return PatcherResult(success=False, error=f"Failed to execute Java: {e}")
 
-        if not output_apk.exists():
-            return PatcherResult(success=False, error="Patching succeeded but output APK not found")
+        return None
 
+    def _sign_apk(self, output_apk: Path) -> PatcherResult | None:
+        """Re-sign the patched APK."""
         temp_signed = output_apk.parent / f"{output_apk.stem}.tmp-signed.apk"
         try:
             signer = APKSigner(
@@ -322,6 +344,10 @@ class ReVancedPatcher:
             temp_signed.unlink(missing_ok=True)
             return PatcherResult(success=False, error=f"Failed to re-sign APK: {e}")
 
+        return None
+
+    def _zipalign_apk(self, output_apk: Path) -> None:
+        """Zipalign the signed APK."""
         aligned_apk = output_apk.parent / f"{output_apk.stem}-aligned.apk"
         if align_apk(output_apk, aligned_apk):
             aligned_apk.replace(output_apk)
@@ -329,8 +355,6 @@ class ReVancedPatcher:
         else:
             logger.warning("zipalign failed, continuing with unaligned APK")
             aligned_apk.unlink(missing_ok=True)
-
-        return PatcherResult(success=True, output_apk=output_apk, version=version)
 
     def _build_patch_args(
         self,


### PR DESCRIPTION
🎯 **What:** The `patch` method in `scripts/builder/patcher.py` was overly complex, merging input validation, command execution, and signing logic into one long block.\n\n💡 **Why:** This refactoring breaks down the `patch` method into smaller, logical chunks (`_verify_inputs`, `_execute_patch_command`, `_sign_apk`, `_zipalign_apk`). This vastly improves the readability and maintainability of the code without altering its control flow or side-effects.\n\n✅ **Verification:** \n- I ran `py_compile` to verify correct Python syntax.\n- I ran the Ruff linter script (`./scripts/lint.sh --fix`) to make sure everything complies with formatting.\n- I executed the test suite (`uv run pytest`) and verified all 233 tests still pass without regression.\n\n✨ **Result:** The `patch` method is now cleanly structured and delegates its responsibilities to modular, self-contained private helper methods.

---
*PR created automatically by Jules for task [11779702281059003492](https://jules.google.com/task/11779702281059003492) started by @Ven0m0*