### PR TITLE
🧹 Remove unused VersionState TypedDict

### DIFF
--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -598,6 +598,7 @@ async def async_download_with_lock(
 
     def _release_lock(fileno: int) -> None:
         import contextlib
+
         fcntl.flock(fileno, fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
             os.close(fileno)

--- a/scripts/version_tracker.py
+++ b/scripts/version_tracker.py
@@ -37,13 +37,6 @@ import orjson
 STATE_FILE: Final[Path] = Path(".github/last_built_versions.json")
 
 
-class VersionState(TypedDict):
-    """State dictionary for version tracking."""
-
-    component: str
-    version: str
-
-
 class AppVersionInfo(TypedDict, total=False):
     """App version information from config."""
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `VersionState` `TypedDict` definition in `scripts/version_tracker.py`. Also formatted `scripts/utils/network.py` by adding an empty line for linting consistency.
💡 **Why:** Dead code removal is a safe and straightforward way to improve codebase readability and maintainability. Removing unused type definitions will not affect the runtime.
✅ **Verification:** Verified by checking if the structure was referenced anywhere via `grep` searches. All tests and lint checks (`./scripts/lint.sh --fix` and `uv run pytest`) passed.
✨ **Result:** Cleaned up code by removing an unused TypedDict, reducing technical debt.

---
*PR created automatically by Jules for task [18028436853327997009](https://jules.google.com/task/18028436853327997009) started by @Ven0m0*