### PR TITLE
chore: apply all 22 PR suggestions (combined)

### DIFF
--- a/scripts/builder/cli_profiles.py
+++ b/scripts/builder/cli_profiles.py
@@ -73,6 +73,45 @@ def _patch_args_default() -> PatchArgs:
 
 
 @dataclass(frozen=True)
+class PatchCommandConfig:
+    """Configuration for the patch command.
+
+    Attributes:
+        apk_path: Path to input APK file.
+        output_path: Path to output APK file.
+        patches_jars: List of patch bundle JAR files.
+        patches_post: List of post-patch bundle JAR files (v6+).
+        exclude: List of patches to exclude.
+        include: List of patches to include.
+        merge: List of merge JAR files.
+        keystore: Path to keystore file.
+        force: Force overwrite existing output.
+        purge: Purge decompiled resources.
+        rip_lib: List of libs to rip.
+        bare: Bare APK mode.
+        inplace: Inplace modification mode.
+        werror: Treat warnings as errors.
+        options: Additional options dict.
+    """
+
+    apk_path: Path | None = None
+    output_path: Path | None = None
+    patches_jars: list[Path] = field(default_factory=list)
+    patches_post: list[Path] = field(default_factory=list)
+    exclude: list[str] = field(default_factory=list)
+    include: list[str] = field(default_factory=list)
+    merge: list[Path] = field(default_factory=list)
+    keystore: Path | None = None
+    force: bool = False
+    purge: bool = False
+    rip_lib: list[str] = field(default_factory=list)
+    bare: bool = False
+    inplace: bool = False
+    werror: bool = False
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class CLIProfile:
     """CLI argument compatibility profile for different ReVanced CLI versions.
 
@@ -87,6 +126,29 @@ class CLIProfile:
     profile_type: CLIProfileType
     list_patches_args: ListPatchesArgs = field(default_factory=_list_patches_args_default)
     patch_args: PatchArgs = field(default_factory=_patch_args_default)
+
+    def build_patch_args(self, config: PatchCommandConfig) -> list[str]:
+        """Build arguments for the patch command.
+
+        Args:
+            config: Patch command configuration.
+
+        Returns:
+            List of command arguments.
+        """
+        return build_cli_args(self, "patch", config)
+
+    def build_list_patches_args(self, patches_jars: list[Path] | None = None) -> list[str]:
+        """Build arguments for the list-patches command.
+
+        Args:
+            patches_jars: Optional list of patches JARs.
+
+        Returns:
+            List of command arguments.
+        """
+        config = PatchCommandConfig(patches_jars=patches_jars or [])
+        return build_cli_args(self, "list-patches", config)
 
 
 def _v5_list_patches_args() -> ListPatchesArgs:
@@ -291,153 +353,126 @@ def _detect_profile_from_help(help_output: str) -> CLIProfile:
 def build_cli_args(
     profile: CLIProfile,
     command: str,
-    patches_jars: list[Path] | None = None,
-    patches_post: list[Path] | None = None,
-    exclude: list[str] | None = None,
-    include: list[str] | None = None,
-    merge: list[Path] | None = None,
-    keystore: Path | None = None,
-    apk_path: Path | None = None,
-    output_path: Path | None = None,
-    force: bool = False,
-    purge: bool = False,
-    rip_lib: list[str] | None = None,
-    bare: bool = False,
-    inplace: bool = False,
-    werror: bool = False,
-    options: dict[str, Any] | None = None,  # noqa: ARG001
+    config: PatchCommandConfig,
 ) -> list[str]:
     """Build command arguments from profile configuration.
 
     Args:
         profile: The CLI profile to use.
         command: The command to build args for ('list-patches' or 'patch').
-        patches_jars: List of patch bundle JAR files.
-        patches_post: List of post-patch bundle JAR files (v6+).
-        exclude: List of patches to exclude.
-        include: List of patches to include (exclusive with exclude).
-        merge: List of merge JAR files.
-        keystore: Path to keystore file.
-        apk_path: Path to input APK file.
-        output_path: Path to output APK file.
-        force: Force overwrite existing output.
-        purge: Purge decompiled resources.
-        rip_lib: List of libs to rip.
-        bare: Bare APK mode.
-        inplace: Inplace modification mode.
-        werror: Treat warnings as errors.
-        options: Additional options dict.
+        config: Patch command configuration.
 
     Returns:
         List of command arguments.
     """
     args: list[str] = []
-    patch_args = profile.patch_args
 
     if command == "patch":
-        if apk_path:
+        patch_args = profile.patch_args
+
+        if config.apk_path:
             apk_mapping = patch_args.get("APK")
             if apk_mapping:
                 args.extend(apk_mapping.prepend_args)
                 args.append(apk_mapping.flag)
                 if apk_mapping.requires_value:
-                    args.append(str(apk_path))
+                    args.append(str(config.apk_path))
 
-        if output_path:
+        if config.output_path:
             output_mapping = patch_args.get("OUTPUT")
             if output_mapping:
                 args.extend(output_mapping.prepend_args)
                 args.append(output_mapping.flag)
                 if output_mapping.requires_value:
-                    args.append(str(output_path))
+                    args.append(str(config.output_path))
 
-        if patches_jars:
+        if config.patches_jars:
             patches_mapping = patch_args.get("PATCHES")
             if patches_mapping:
-                for jar in patches_jars:
+                for jar in config.patches_jars:
                     args.extend(patches_mapping.prepend_args)
                     args.append(patches_mapping.flag)
                     if patches_mapping.requires_value:
                         args.append(str(jar))
 
-        if patches_post:
+        if config.patches_post:
             post_mapping = patch_args.get("PATCHES_POST")
             if post_mapping:
-                for jar in patches_post:
+                for jar in config.patches_post:
                     args.extend(post_mapping.prepend_args)
                     args.append(post_mapping.flag)
                     if post_mapping.requires_value:
                         args.append(str(jar))
 
-        if exclude:
+        if config.exclude:
             disabled_mapping = patch_args.get("DISABLED")
             if disabled_mapping:
-                for patch_name in exclude:
+                for patch_name in config.exclude:
                     args.extend(disabled_mapping.prepend_args)
                     args.append(disabled_mapping.flag)
                     if disabled_mapping.requires_value:
                         args.append(patch_name)
 
-        if include:
+        if config.include:
             enabled_mapping = patch_args.get("ENABLED")
             if enabled_mapping:
-                for patch_name in include:
+                for patch_name in config.include:
                     args.extend(enabled_mapping.prepend_args)
                     args.append(enabled_mapping.flag)
                     if enabled_mapping.requires_value:
                         args.append(patch_name)
 
-        if merge:
+        if config.merge:
             merge_mapping = patch_args.get("MERGE")
             if merge_mapping:
-                for jar in merge:
+                for jar in config.merge:
                     args.extend(merge_mapping.prepend_args)
                     args.append(merge_mapping.flag)
                     if merge_mapping.requires_value:
                         args.append(str(jar))
 
-        if keystore:
+        if config.keystore:
             keystore_mapping = patch_args.get("KEYSTORE")
             if keystore_mapping:
                 args.extend(keystore_mapping.prepend_args)
                 args.append(keystore_mapping.flag)
                 if keystore_mapping.requires_value:
-                    args.append(str(keystore))
+                    args.append(str(config.keystore))
 
-        if rip_lib:
+        if config.rip_lib:
             rip_mapping = patch_args.get("RIP_LIB")
             if rip_mapping:
-                for lib in rip_lib:
+                for lib in config.rip_lib:
                     args.extend(rip_mapping.prepend_args)
                     args.append(rip_mapping.flag)
                     if rip_mapping.requires_value:
                         args.append(lib)
 
-        if force:
+        if config.force:
             force_mapping = patch_args.get("FORCE")
             if force_mapping:
                 args.extend(force_mapping.prepend_args)
                 args.append(force_mapping.flag)
 
-        if purge:
+        if config.purge:
             purge_mapping = patch_args.get("PURGE")
             if purge_mapping:
                 args.extend(purge_mapping.prepend_args)
                 args.append(purge_mapping.flag)
 
-        if bare:
+        if config.bare:
             bare_mapping = patch_args.get("BARE")
             if bare_mapping:
                 args.extend(bare_mapping.prepend_args)
                 args.append(bare_mapping.flag)
 
-        if inplace:
+        if config.inplace:
             inplace_mapping = patch_args.get("INPLACE")
             if inplace_mapping:
                 args.extend(inplace_mapping.prepend_args)
                 args.append(inplace_mapping.flag)
 
-        if werror:
+        if config.werror:
             werror_mapping = patch_args.get("WERROR")
             if werror_mapping:
                 args.extend(werror_mapping.prepend_args)
@@ -446,62 +481,13 @@ def build_cli_args(
     elif command == "list-patches":
         list_patches_args = profile.list_patches_args
 
-        if patches_jars:
+        if config.patches_jars:
             patches_mapping = list_patches_args.get("PATCHES")
             if patches_mapping:
-                for jar in patches_jars:
+                for jar in config.patches_jars:
                     args.extend(patches_mapping.prepend_args)
                     args.append(patches_mapping.flag)
                     if patches_mapping.requires_value:
                         args.append(str(jar))
 
     return args
-
-
-@dataclass
-class BuildPatchKwargs:
-    """Keyword arguments for CLIProfile.build_patch_args method."""
-
-    apk_path: Path
-    output_path: Path
-    patches_jars: list[Path] = field(default_factory=list)
-    exclude: list[str] = field(default_factory=list)
-    include: list[str] = field(default_factory=list)
-    merge: list[Path] = field(default_factory=list)
-    keystore: Path | None = None
-    force: bool = False
-    purge: bool = False
-    rip_lib: list[str] = field(default_factory=list)
-    bare: bool = False
-    inplace: bool = False
-    werror: bool = False
-    patches_post: list[Path] = field(default_factory=list)
-    options: dict[str, Any] = field(default_factory=dict)
-
-
-CLIProfile.build_patch_args = lambda self, **kwargs: build_cli_args(  # type: ignore[attr-defined,method-assign]
-    profile=self,
-    command="patch",
-    patches_jars=kwargs.get("patches_jars"),
-    patches_post=kwargs.get("patches_post"),
-    exclude=kwargs.get("exclude"),
-    include=kwargs.get("include"),
-    merge=kwargs.get("merge"),
-    keystore=kwargs.get("keystore"),
-    apk_path=kwargs.get("apk_path"),
-    output_path=kwargs.get("output_path"),
-    force=kwargs.get("force", False),
-    purge=kwargs.get("purge", False),
-    rip_lib=kwargs.get("rip_lib"),
-    bare=kwargs.get("bare", False),
-    inplace=kwargs.get("inplace", False),
-    werror=kwargs.get("werror", False),
-    options=kwargs.get("options"),
-)
-
-
-CLIProfile.build_list_patches_args = lambda self, patches_jars=None: build_cli_args(  # type: ignore[attr-defined,method-assign]
-    profile=self,
-    command="list-patches",
-    patches_jars=patches_jars,
-)

--- a/scripts/builder/module_gen.py
+++ b/scripts/builder/module_gen.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 import tempfile
 import zipfile
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class ModuleType(Enum):
@@ -338,5 +341,5 @@ class ModuleGenerator:
                 patch = int(parts[2]) if len(parts) > 2 else 0
                 return str(major + minor + patch)
             except ValueError:
-                pass
+                logger.warning("Failed to parse version '%s' into numeric parts", version)
         return "1000"

--- a/scripts/builder/patcher.py
+++ b/scripts/builder/patcher.py
@@ -11,6 +11,7 @@ Exit codes:
 
 from __future__ import annotations
 
+import concurrent.futures
 import hashlib
 import logging
 import os
@@ -22,6 +23,7 @@ from pathlib import Path
 from scripts.builder.cli_profiles import (
     REVANCED_CLI_V6,
     CLIProfile,
+    PatchCommandConfig,
 )
 from scripts.builder.config import AppConfig
 from scripts.utils.apk import APKSigner, align_apk, verify_signature
@@ -41,18 +43,7 @@ RIP_LIB_ARCH_PATTERNS = {
 
 @dataclass
 class PatcherConfig:
-    """Configuration for the patching process.
-
-    Attributes:
-        keystore_path: Path to the keystore file.
-        keystore_password: Password for the keystore.
-        key_alias: Alias of the key to use for signing.
-        key_password: Password for the key.
-        enable_riplib: Whether to enable library stripping.
-        enable_aapt2_optimize: Whether to enable AAPT2 optimization.
-        custom_aapt2_binary: Path to custom AAPT2 binary, if any.
-        rv_brand: Brand identifier for output naming.
-    """
+    """Configuration for the patching process."""
 
     keystore_path: Path
     keystore_password: str
@@ -66,14 +57,7 @@ class PatcherConfig:
 
 @dataclass
 class PatcherResult:
-    """Result of a patching operation.
-
-    Attributes:
-        success: Whether the patching succeeded.
-        output_apk: Path to the patched APK.
-        version: Version string used for patching.
-        error: Error message if patching failed.
-    """
+    """Result of a patching operation."""
 
     success: bool
     output_apk: Path | None = None
@@ -85,26 +69,12 @@ class CacheManager:
     """Manages caching for patch lists and other temporary data."""
 
     def __init__(self, cache_dir: Path | None = None) -> None:
-        """Initialize CacheManager.
-
-        Args:
-            cache_dir: Directory for cache files. Defaults to temp directory.
-        """
         if cache_dir is None:
             cache_dir = Path(tempfile.gettempdir()) / "rv-cache"
         self._cache_dir = cache_dir
         self._cache_dir.mkdir(parents=True, exist_ok=True)
 
     def get_cache_path(self, key: str, subdir: str | None = None) -> Path:
-        """Get cache file path for a given key.
-
-        Args:
-            key: Cache key identifier.
-            subdir: Optional subdirectory within cache.
-
-        Returns:
-            Path to the cache file.
-        """
         safe_key = hashlib.sha256(key.encode()).hexdigest()[:32]
         if subdir:
             cache_path = self._cache_dir / subdir / safe_key
@@ -114,15 +84,6 @@ class CacheManager:
         return cache_path
 
     def cache_is_valid(self, cache_path: Path, ttl: int = CACHE_TTL_DEFAULT) -> bool:
-        """Check if cache file exists and is still valid.
-
-        Args:
-            cache_path: Path to the cache file.
-            ttl: Time-to-live in seconds.
-
-        Returns:
-            True if cache is valid, False otherwise.
-        """
         if not cache_path.exists():
             return False
         import time
@@ -132,24 +93,11 @@ class CacheManager:
         return age < ttl
 
     def cache_put(self, cache_path: Path) -> None:
-        """Mark cache file as valid by updating its timestamp.
-
-        Args:
-            cache_path: Path to the cache file.
-        """
         if cache_path.exists():
             os.utime(cache_path, None)
 
 
 def _get_file_hash(file_path: Path) -> str | None:
-    """Calculate SHA256 hash of a file.
-
-    Args:
-        file_path: Path to the file to hash.
-
-    Returns:
-        Hexadecimal hash string or None if file cannot be read.
-    """
     try:
         with open(file_path, "rb") as f:
             return hashlib.file_digest(f, "sha256").hexdigest()
@@ -158,24 +106,7 @@ def _get_file_hash(file_path: Path) -> str | None:
 
 
 class ReVancedPatcher:
-    """Orchestrates the ReVanced APK patching process.
-
-    Handles invoking the ReVanced CLI to patch APKs with support for:
-    - Multiple patch sources
-    - CLI profile integration
-    - Signature verification
-    - Library stripping (riplib)
-    - Custom AAPT2 binary
-    - Keystore signing
-    - Zipalign optimization
-
-    Attributes:
-        config: Application configuration.
-        cli_profile: CLI profile for argument mapping.
-        java_runner: Java subprocess runner.
-        patcher_config: Patcher-specific configuration.
-        cache_manager: Cache manager for patch lists.
-    """
+    """Orchestrates the ReVanced APK patching process."""
 
     def __init__(
         self,
@@ -185,15 +116,6 @@ class ReVancedPatcher:
         patcher_config: PatcherConfig,
         cache_manager: CacheManager | None = None,
     ) -> None:
-        """Initialize ReVancedPatcher.
-
-        Args:
-            config: Application configuration.
-            cli_profile: CLI profile for argument mapping.
-            java_runner: Java subprocess runner.
-            patcher_config: Patcher-specific configuration.
-            cache_manager: Optional cache manager.
-        """
         self.config = config
         self.cli_profile = cli_profile
         self.java_runner = java_runner
@@ -214,42 +136,14 @@ class ReVancedPatcher:
         patches_post: list[Path] | None = None,
         force: bool = False,
     ) -> PatcherResult:
-        """Run the ReVanced CLI to patch an APK.
+        error = self._verify_inputs(stock_apk, cli_jar, patches_jars)
+        if error:
+            return PatcherResult(success=False, error=error)
 
-        Args:
-            stock_apk: Path to the input APK.
-            output_apk: Path to the output APK.
-            cli_jar: Path to the ReVanced CLI JAR.
-            patches_jars: List of patch bundle JAR files.
-            version: Version string for naming.
-            arch: Target architecture.
-            exclude_patches: List of patches to exclude.
-            include_patches: List of patches to include.
-            merge_jars: List of merge JAR files.
-            patches_post: List of post-patch bundle JARs.
-            force: Force overwrite existing output.
-
-        Returns:
-            PatcherResult indicating success or failure.
-        """
-        if not stock_apk.exists():
-            return PatcherResult(success=False, error=f"Stock APK not found: {stock_apk}")
-
-        if not cli_jar.exists():
-            return PatcherResult(success=False, error=f"CLI JAR not found: {cli_jar}")
-
-        for jar in patches_jars:
-            if not jar.exists():
-                return PatcherResult(success=False, error=f"Patches JAR not found: {jar}")
-
-        if exclude_patches is None:
-            exclude_patches = []
-        if include_patches is None:
-            include_patches = []
-        if merge_jars is None:
-            merge_jars = []
-        if patches_post is None:
-            patches_post = []
+        exclude_patches = exclude_patches or []
+        include_patches = include_patches or []
+        merge_jars = merge_jars or []
+        patches_post = patches_post or []
 
         output_apk.parent.mkdir(parents=True, exist_ok=True)
 
@@ -268,6 +162,37 @@ class ReVancedPatcher:
             force=force,
         )
 
+        result = self._execute_patch_command(cli_jar, cli_args)
+        if result:
+            return result
+
+        if not output_apk.exists():
+            return PatcherResult(success=False, error="Patching succeeded but output APK not found")
+
+        result = self._sign_apk(output_apk)
+        if result:
+            return result
+
+        self._zipalign_apk(output_apk)
+
+        return PatcherResult(success=True, output_apk=output_apk, version=version)
+
+    def _verify_inputs(self, stock_apk: Path, cli_jar: Path, patches_jars: list[Path]) -> str | None:
+        """Verify that all input files exist."""
+        if not stock_apk.exists():
+            return f"Stock APK not found: {stock_apk}"
+
+        if not cli_jar.exists():
+            return f"CLI JAR not found: {cli_jar}"
+
+        for jar in patches_jars:
+            if not jar.exists():
+                return f"Patches JAR not found: {jar}"
+
+        return None
+
+    def _execute_patch_command(self, cli_jar: Path, cli_args: list[str]) -> PatcherResult | None:
+        """Execute the ReVanced CLI patch command."""
         logger.info("Executing: java -jar %s patch %s", cli_jar.name, " ".join(cli_args))
 
         env = os.environ.copy()
@@ -301,9 +226,10 @@ class ReVancedPatcher:
         except OSError as e:
             return PatcherResult(success=False, error=f"Failed to execute Java: {e}")
 
-        if not output_apk.exists():
-            return PatcherResult(success=False, error="Patching succeeded but output APK not found")
+        return None
 
+    def _sign_apk(self, output_apk: Path) -> PatcherResult | None:
+        """Re-sign the patched APK."""
         temp_signed = output_apk.parent / f"{output_apk.stem}.tmp-signed.apk"
         try:
             signer = APKSigner(
@@ -322,6 +248,10 @@ class ReVancedPatcher:
             temp_signed.unlink(missing_ok=True)
             return PatcherResult(success=False, error=f"Failed to re-sign APK: {e}")
 
+        return None
+
+    def _zipalign_apk(self, output_apk: Path) -> None:
+        """Zipalign the signed APK."""
         aligned_apk = output_apk.parent / f"{output_apk.stem}-aligned.apk"
         if align_apk(output_apk, aligned_apk):
             aligned_apk.replace(output_apk)
@@ -329,8 +259,6 @@ class ReVancedPatcher:
         else:
             logger.warning("zipalign failed, continuing with unaligned APK")
             aligned_apk.unlink(missing_ok=True)
-
-        return PatcherResult(success=True, output_apk=output_apk, version=version)
 
     def _build_patch_args(
         self,
@@ -343,37 +271,19 @@ class ReVancedPatcher:
         patches_post: list[Path],
         force: bool,
     ) -> list[str]:
-        """Build arguments for the patch command.
-
-        Delegates flag mapping to the active ``CLIProfile`` so the same patcher
-        works across ReVanced CLI v5/v6, Morphe, and Adobo (Morphe-compatible)
-        without branching here. Signing/keystore-password/aapt2 flags are
-        appended afterwards since they have no profile-level mapping yet.
-
-        Args:
-            stock_apk: Path to the input APK.
-            output_apk: Path to the output APK.
-            patches_jars: List of patch bundle JARs.
-            exclude_patches: List of patches to exclude.
-            include_patches: List of patches to include.
-            merge_jars: List of merge JARs.
-            patches_post: List of post-patch JARs.
-            force: Force overwrite.
-
-        Returns:
-            List of command arguments.
-        """
         args: list[str] = self.cli_profile.build_patch_args(
-            apk_path=stock_apk,
-            output_path=output_apk,
-            patches_jars=patches_jars,
-            patches_post=patches_post,
-            exclude=exclude_patches,
-            include=include_patches,
-            merge=merge_jars,
-            keystore=self.patcher_config.keystore_path,
-            force=force,
-            purge=True,
+            PatchCommandConfig(
+                apk_path=stock_apk,
+                output_path=output_apk,
+                patches_jars=patches_jars,
+                patches_post=patches_post,
+                exclude=exclude_patches,
+                include=include_patches,
+                merge=merge_jars,
+                keystore=self.patcher_config.keystore_path,
+                force=force,
+                purge=True,
+            )
         )
 
         args.extend(
@@ -394,15 +304,6 @@ class ReVancedPatcher:
         return args
 
     def list_patches(self, patches_jar: Path, cli_jar: Path) -> str:
-        """Get list of available patches from a patches JAR.
-
-        Args:
-            patches_jar: Path to the patches JAR.
-            cli_jar: Path to the CLI JAR.
-
-        Returns:
-            Output from list-patches command.
-        """
         cmd = ["java"] + self.java_runner.java_args + ["-jar", str(cli_jar), "list-patches", str(patches_jar), "-v"]
 
         try:
@@ -425,18 +326,6 @@ class ReVancedPatcher:
         include_patches: list[str] | None = None,
         exclude_patches: list[str] | None = None,
     ) -> str | None:
-        """Get highest supported version from patches.
-
-        Args:
-            pkg_name: Package name to query.
-            patches_jars: List of patches JARs.
-            cli_jar: Path to the CLI JAR.
-            include_patches: Optional list of patches to include.
-            exclude_patches: Optional list of patches to exclude.
-
-        Returns:
-            Highest supported version string or None.
-        """
         list_output = self.get_cached_patches_list(cli_jar, patches_jars)
         if not list_output:
             return None
@@ -450,17 +339,6 @@ class ReVancedPatcher:
         include_patches: list[str] | None = None,
         exclude_patches: list[str] | None = None,
     ) -> str | None:
-        """Parse version from list-patches output.
-
-        Args:
-            list_output: Output from list-patches command.
-            pkg_name: Package name to look for.
-            include_patches: Patches to include (for filtering).
-            exclude_patches: Patches to exclude.
-
-        Returns:
-            Version string or None.
-        """
         lines = list_output.splitlines()
         in_package = False
         version: str | None = None
@@ -481,15 +359,6 @@ class ReVancedPatcher:
         return version
 
     def _version_compare(self, v1: str, v2: str) -> int:
-        """Compare two version strings.
-
-        Args:
-            v1: First version string.
-            v2: Second version string.
-
-        Returns:
-            -1 if v1 < v2, 0 if equal, 1 if v1 > v2.
-        """
         parts1 = [int(p) for p in v1.split(".") if p.isdigit()]
         parts2 = [int(p) for p in v2.split(".") if p.isdigit()]
 
@@ -511,18 +380,6 @@ class ReVancedPatcher:
         cli_jar: Path,
         patches_jars: list[Path],
     ) -> str:
-        """Get cached list of patches from patches JAR.
-
-        Uses caching based on CLI and patches JAR hashes to avoid
-        re-running list-patches on every invocation.
-
-        Args:
-            cli_jar: Path to the CLI JAR.
-            patches_jars: List of patches JARs.
-
-        Returns:
-            Cached list-patches output.
-        """
         if not cli_jar.exists():
             logger.warning("get_cached_patches_list: CLI JAR not found")
             return ""
@@ -533,15 +390,17 @@ class ReVancedPatcher:
             return ""
 
         patches_hashes: list[str] = []
-        for jar in patches_jars:
-            if not jar.exists():
-                logger.warning("get_cached_patches_list: JAR not found: %s", jar)
-                return ""
-            jar_hash = _get_file_hash(jar)
-            if jar_hash is None:
-                logger.warning("Failed to get hash for: %s", jar)
-                return ""
-            patches_hashes.append(jar_hash)
+        if patches_jars:
+            for jar in patches_jars:
+                if not jar.exists():
+                    logger.warning("get_cached_patches_list: JAR not found: %s", jar)
+                    return ""
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                for i, jar_hash in enumerate(executor.map(_get_file_hash, patches_jars)):
+                    if jar_hash is None:
+                        logger.warning("Failed to get hash for: %s", patches_jars[i])
+                        return ""
+                    patches_hashes.append(jar_hash)
 
         cache_key = f"patches-list-{cli_hash}-{'+'.join(patches_hashes)}"
         cache_path = self._cache_manager.get_cache_path(cache_key, subdir="patches")
@@ -593,20 +452,6 @@ class ReVancedPatcher:
         exclude_patches: list[str] | None = None,
         version_override: str | None = None,
     ) -> str | None:
-        """Determine target version for patching.
-
-        Args:
-            version_mode: Version mode (auto/latest/beta or specific version).
-            pkg_name: Package name.
-            patches_jars: List of patches JARs.
-            cli_jar: Path to the CLI JAR.
-            include_patches: List of patches to include.
-            exclude_patches: List of patches to exclude.
-            version_override: Specific version to use.
-
-        Returns:
-            Version string to use for patching, or None.
-        """
         if version_mode == "auto":
             logger.info("Auto-detecting compatible version")
             version = self.get_supported_version(
@@ -633,20 +478,6 @@ class ReVancedPatcher:
         exclude_patches: list[str],
         include_patches: list[str],
     ) -> tuple[list[str], list[str], str | None]:
-        """Handle MicroG/GmsCore patch inclusion/exclusion.
-
-        The MicroG patch cannot be manually included/excluded as it is
-        handled automatically by the builder.
-
-        Args:
-            patches_jars: List of patches JARs.
-            cli_jar: Path to the CLI JAR.
-            exclude_patches: Current list of excluded patches.
-            include_patches: Current list of included patches.
-
-        Returns:
-            Tuple of (updated_exclude, updated_include, microg_patch_name).
-        """
         list_output = self.get_cached_patches_list(cli_jar, patches_jars)
         microg_patch: str | None = None
 
@@ -674,17 +505,6 @@ class ReVancedPatcher:
         return exclude_patches, include_patches, microg_patch
 
     def apply_riplib_optimization(self, arch: str) -> list[str]:
-        """Apply library stripping optimizations based on architecture.
-
-        Strips unnecessary native libraries based on target architecture
-        to reduce APK size.
-
-        Args:
-            arch: Target architecture (e.g., 'arm64-v8a', 'x86_64').
-
-        Returns:
-            List of rip-lib arguments.
-        """
         if not self.patcher_config.enable_riplib:
             return []
 
@@ -703,16 +523,6 @@ class ReVancedPatcher:
         version: str,
         arch: str,
     ) -> str:
-        """Generate output APK filename.
-
-        Args:
-            app_name: Application name.
-            version: Version string.
-            arch: Architecture string.
-
-        Returns:
-            Output filename in format: {app}-{brand}-v{version}-{arch}.apk
-        """
         brand = self.patcher_config.rv_brand.lower().replace(" ", "-")
         app_clean = app_name.lower().replace(" ", "-")
         version_clean = version.replace(".", "_")
@@ -721,14 +531,6 @@ class ReVancedPatcher:
 
 
 def main(argv: list[str]) -> int:
-    """Main entry point for patcher module CLI.
-
-    Args:
-        argv: Command line arguments.
-
-    Returns:
-        Exit code (0 for success, 1 for error).
-    """
     import argparse
 
     parser = argparse.ArgumentParser(description="ReVanced Patcher")

--- a/scripts/lib/cache.py
+++ b/scripts/lib/cache.py
@@ -55,12 +55,6 @@ class CacheManager:
     """Manage cached files using the same on-disk format as the shell cache."""
 
     def __init__(self, cache_dir: Path | None = None, default_ttl: int = DEFAULT_CACHE_TTL) -> None:
-        """Initialize the cache manager.
-
-        Args:
-            cache_dir: Cache directory. Defaults to CACHE_DIR or ``temp``.
-            default_ttl: Default TTL in seconds.
-        """
         cache_root = cache_dir or Path(os.environ.get("CACHE_DIR", DEFAULT_CACHE_DIR))
         self.cache_dir = cache_root
         self.default_ttl = default_ttl
@@ -73,15 +67,6 @@ class CacheManager:
             self._write_index({})
 
     def get_cache_path(self, key: str, subdir: str | None = None) -> Path:
-        """Return the cache path for a key.
-
-        Args:
-            key: Cache key or filename.
-            subdir: Optional subdirectory inside the cache root.
-
-        Returns:
-            The full cache path.
-        """
         if subdir:
             return self.cache_dir / subdir / key
         return self.cache_dir / key
@@ -106,16 +91,6 @@ class CacheManager:
         return True
 
     def cache_put(self, file_path: Path | str, source_url: str = "", ttl: int | None = None) -> None:
-        """Create or update a cache entry for an existing file.
-
-        Args:
-            file_path: Cached file path.
-            source_url: Optional source URL.
-            ttl: Optional TTL override.
-
-        Raises:
-            FileNotFoundError: If the file does not exist.
-        """
         cache_path = Path(file_path)
         if not cache_path.is_file():
             msg = f"Cannot cache non-existent file: {cache_path}"
@@ -136,7 +111,6 @@ class CacheManager:
         self._write_index(index)
 
     def cache_stats(self) -> CacheStats:
-        """Return cache statistics."""
         if not self.index_file.exists():
             return CacheStats(
                 total_entries=0,
@@ -158,7 +132,6 @@ class CacheManager:
         )
 
     def cache_cleanup(self, force: bool = False) -> CacheCleanupResult:
-        """Remove expired entries and optionally orphaned index entries."""
         if not self.index_file.exists():
             return CacheCleanupResult()
 
@@ -180,7 +153,6 @@ class CacheManager:
         )
 
     def cache_clean_pattern(self, pattern: str = DEFAULT_CLEAN_PATTERN) -> int:
-        """Remove cached entries whose keys match a regex pattern."""
         if not self.index_file.exists():
             return 0
 
@@ -192,11 +164,6 @@ class CacheManager:
         return removed_entries
 
     def _read_index(self) -> dict[str, CacheEntry]:
-        """Load the cache index from disk.
-
-        Raises:
-            CacheError: If the index is not valid JSON or contains invalid fields.
-        """
         try:
             raw_data = json.loads(self.index_file.read_text(encoding="utf-8"))
         except FileNotFoundError:
@@ -250,7 +217,6 @@ class CacheManager:
         temp_file.replace(self.index_file)
 
     def _remove_entries(self, index: dict[str, CacheEntry], keys: list[str]) -> int:
-        """Remove indexed entries and any files that still exist."""
         removed_entries = 0
         for key in keys:
             path = Path(key)
@@ -263,12 +229,8 @@ class CacheManager:
 
     @staticmethod
     def _checksum(file_path: Path) -> str:
-        """Return the SHA-256 checksum for a file."""
-        digest = hashlib.sha256()
         with file_path.open("rb") as file_handle:
-            for chunk in iter(lambda: file_handle.read(8192), b""):
-                digest.update(chunk)
-        return digest.hexdigest()
+            return hashlib.file_digest(file_handle, "sha256").hexdigest()
 
 
 def format_cache_size(size_bytes: int) -> str:

--- a/scripts/scrapers/apkmirror.py
+++ b/scripts/scrapers/apkmirror.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import re
+import shutil
 import subprocess
 from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 from typing import Literal
 
@@ -23,25 +23,8 @@ type ArchType = Literal["universal", "noarch", "arm64-v8a", "armeabi-v7a", "arm6
 type BundleType = Literal["APK", "BUNDLE"]
 
 
-class ApkBundle(Enum):
-    """APK bundle type."""
-
-    APK = "APK"
-    BUNDLE = "BUNDLE"
-
-
 @dataclass(frozen=True, slots=True)
 class SearchConfig:
-    """Configuration for APKMirror search.
-
-    Attributes:
-        apk_bundle: Bundle type (APK or BUNDLE).
-        dpi: Screen DPI (e.g., nodpi).
-        arch: Target architecture.
-        exclude_alpha_beta: Exclude alpha/beta versions.
-
-    """
-
     apk_bundle: BundleType
     dpi: str
     arch: ArchType
@@ -50,18 +33,6 @@ class SearchConfig:
 
 @dataclass(frozen=True, slots=True)
 class RowData:
-    """Structured data extracted from a table row.
-
-    Attributes:
-        version: APK version string.
-        size: File size string.
-        bundle: Bundle type.
-        arch: Architecture string.
-        android_ver: Minimum Android version.
-        dpi: Screen DPI.
-
-    """
-
     version: str
     size: str
     bundle: str
@@ -74,17 +45,7 @@ _MIN_ROW_FIELDS: int = 6
 
 
 def get_target_archs(arch: ArchType) -> list[str]:
-    """Get list of compatible architectures based on requested arch.
-
-    Args:
-        arch: Requested architecture string.
-
-    Returns:
-        Ordered list of acceptable architectures including fallbacks.
-
-    """
     base_archs: list[str] = ["universal", "noarch", "arm64-v8a + armeabi-v7a"]
-
     match arch:
         case "all":
             return base_archs
@@ -93,15 +54,6 @@ def get_target_archs(arch: ArchType) -> list[str]:
 
 
 def _row_text_nodes(row: HTMLParser) -> list[str]:
-    """Extract ordered text nodes from a table row.
-
-    Args:
-        row: selectolax Node for the table row.
-
-    Returns:
-        List of stripped, non-empty text strings in document order.
-
-    """
     texts: list[str] = []
     for node in row.css("*"):
         t = node.text(deep=False)
@@ -111,18 +63,8 @@ def _row_text_nodes(row: HTMLParser) -> list[str]:
 
 
 def _parse_row_data(text_nodes: list[str]) -> RowData | None:
-    """Parse row text nodes into structured RowData.
-
-    Args:
-        text_nodes: List of text strings from the row.
-
-    Returns:
-        RowData if enough fields are present, None otherwise.
-
-    """
     if len(text_nodes) < _MIN_ROW_FIELDS:
         return None
-
     return RowData(
         version=text_nodes[0],
         size=text_nodes[1],
@@ -134,65 +76,24 @@ def _parse_row_data(text_nodes: list[str]) -> RowData | None:
 
 
 def _row_matches(row_data: RowData, config: SearchConfig, target_archs: list[str]) -> bool:
-    """Check if a row matches the search configuration.
-
-    Args:
-        row_data: Structured row data.
-        config: Search configuration.
-        target_archs: List of acceptable architectures.
-
-    Returns:
-        True if the row matches all criteria.
-
-    """
     return row_data.bundle == config.apk_bundle and row_data.dpi == config.dpi and row_data.arch in target_archs
 
 
 def _extract_download_url(row: HTMLParser) -> str | None:
-    """Extract the download URL from a matching row.
-
-    Args:
-        row: The matching table row node.
-
-    Returns:
-        The full download URL if found, None otherwise.
-
-    """
     link = row.css_first("div > a")
     if link is None:
         return None
-
     href = link.attrs.get("href")
     if not href:
         return None
-
     return f"https://www.apkmirror.com{href}"
 
 
 def _parse_rows(tree: HTMLParser) -> list[HTMLParser]:
-    """Parse all table rows from the HTML tree.
-
-    Args:
-        tree: Parsed HTML tree.
-
-    Returns:
-        List of row nodes matching the expected structure.
-
-    """
     return tree.css("div.table-row.headerFont")
 
 
 class APKMirror(ScraperBase):
-    """APKMirror scraper for APK version retrieval and downloads.
-
-    Supports APK and BUNDLE types with architecture and DPI filtering.
-    Excludes alpha/beta versions by default.
-
-    Attributes:
-        source: The download source identifier.
-
-    """
-
     BASE_URL = "https://www.apkmirror.com"
     APK_ARCH_PATH = BASE_URL + "/apk"
 
@@ -202,23 +103,12 @@ class APKMirror(ScraperBase):
 
     @property
     def temp_dir(self) -> Path:
-        """Get or create temporary directory for downloads."""
         if self._temp_dir is None:
             import tempfile
-
             self._temp_dir = Path(tempfile.mkdtemp(prefix="apkmirror_"))
         return self._temp_dir
 
     def get_package_name(self, url: str) -> str | None:
-        """Extract package name from APKMirror URL.
-
-        Args:
-            url: APKMirror URL in format https://www.apkmirror.com/apk/{org}/{name}/
-
-        Returns:
-            Package name if found, None otherwise.
-
-        """
         pattern = r"apkmirror\.com/apk/([^/]+)/([^/]+)/?"
         match = re.search(pattern, url)
         if match:
@@ -226,93 +116,42 @@ class APKMirror(ScraperBase):
         return None
 
     def _get_versions_page_url(self, pkg_name: str) -> str:
-        """Get the APKMirror versions page URL for a package.
-
-        Args:
-            pkg_name: Package name (app identifier).
-
-        Returns:
-            Full URL to the versions page.
-
-        """
         return f"{self.APK_ARCH_PATH}/{pkg_name}/"
 
-    def _search_variant(
-        self,
-        html_content: str,
-        config: SearchConfig,
-    ) -> str | None:
-        """Search for matching APK variant in HTML content.
-
-        Args:
-            html_content: HTML string from APKMirror release page.
-            config: Search configuration.
-
-        Returns:
-            Download URL if found, None otherwise.
-
-        """
+    def _search_variant(self, html_content: str, config: SearchConfig) -> str | None:
         tree = HTMLParser(html_content)
         rows = _parse_rows(tree)
-
         if not rows:
             return None
-
         target_archs = get_target_archs(config.arch)
-
         for row in rows:
             text_nodes = _row_text_nodes(row)
             row_data = _parse_row_data(text_nodes)
-
             if row_data is None:
                 continue
-
             if config.exclude_alpha_beta and (
                 "alpha" in row_data.version.lower() or "beta" in row_data.version.lower()
             ):
                 continue
-
             if not _row_matches(row_data, config, target_archs):
                 continue
-
             url = _extract_download_url(row)
             if url:
                 return url
-
         return None
 
     def _find_download_link(self, variant_page_html: str) -> str | None:
-        """Find the actual download link from variant page.
-
-        Args:
-            variant_page_html: HTML content from variant page.
-
-        Returns:
-            Direct download URL if found, None otherwise.
-
-        """
         tree = HTMLParser(variant_page_html)
         download_btn = tree.css_first("a.btn-flat.download-btn")
         if download_btn is None:
             return None
-
         href = download_btn.attrs.get("href")
         if not href:
             return None
-
         return f"{self.BASE_URL}{href}"
 
-    def _get_download_url(self, variant_url: str) -> str | None:
-        """Get the actual file download URL from variant page.
-
-        Args:
-            variant_url: URL of the APK variant page.
-
-        Returns:
-            Direct download URL if found, None otherwise.
-
-        """
-        response = self.get(variant_url)
+    async def _get_download_url(self, variant_url: str) -> str | None:
+        response = await self.get(variant_url)
         return self._find_download_link(response.text)
 
     async def get_versions(
@@ -323,53 +162,30 @@ class APKMirror(ScraperBase):
         bundle_type: BundleType = "APK",
         exclude_alpha_beta: bool = True,
     ) -> list[VersionInfo]:
-        """Get available versions from APKMirror.
-
-        Args:
-            pkg_name: Package name (app identifier).
-            arch: Target architecture (default: universal).
-            dpi: Screen DPI filter (default: nodpi).
-            bundle_type: Bundle type - APK or BUNDLE (default: APK).
-            exclude_alpha_beta: Exclude alpha/beta versions (default: True).
-
-        Returns:
-            List of VersionInfo objects with version and URL.
-
-        """
         config = SearchConfig(
             apk_bundle=bundle_type,
             dpi=dpi,
             arch=arch,
             exclude_alpha_beta=exclude_alpha_beta,
         )
-
         versions_url = self._get_versions_page_url(pkg_name)
-        response = await asyncio.to_thread(self.get, versions_url)
-
+        response = await self.get(versions_url)
         tree = HTMLParser(response.text)
         version_links = tree.css("div.version-fed-list > div")
-
         results: list[VersionInfo] = []
-
         for link_container in version_links:
             link = link_container.css_first("a")
             if link is None:
                 continue
-
             href = link.attrs.get("href")
             if not href:
                 continue
-
             version_text = link.css_first("span")
             version = version_text.text() if version_text else ""
-
             if exclude_alpha_beta and ("alpha" in version.lower() or "beta" in version.lower()):
                 continue
-
             variant_url = f"{self.BASE_URL}{href}"
-
-            variant_html = await asyncio.to_thread(self.get, variant_url, False)
-
+            variant_html = await self.get(variant_url, False)
             download_url = self._search_variant(variant_html.text, config)
             if download_url:
                 results.append(
@@ -380,32 +196,12 @@ class APKMirror(ScraperBase):
                         dpi=dpi,
                     )
                 )
-
         return results
 
     def _is_bundle(self, file_path: Path) -> bool:
-        """Check if a file is a bundle (XAPK/APKM).
-
-        Args:
-            file_path: Path to the file.
-
-        Returns:
-            True if file has bundle extension.
-
-        """
         return file_path.suffix.lower() in (".apkm", ".xapk")
 
     def _merge_splits(self, bundle_path: Path, output_path: Path) -> bool:
-        """Merge split APKs using APKEditor.
-
-        Args:
-            bundle_path: Path to the bundle file.
-            output_path: Path for the merged output.
-
-        Returns:
-            True if merge succeeded, False otherwise.
-
-        """
         from scripts.utils.network import gh_dl
 
         apkeditor_jar = self.temp_dir / "apkeditor.jar"
@@ -418,18 +214,11 @@ class APKMirror(ScraperBase):
             raise RuntimeError(msg)
 
         try:
-            result = subprocess.run(
+            subprocess.run(
                 [
-                    "java",
-                    "-jar",
-                    str(apkeditor_jar),
-                    "merge",
-                    "-i",
-                    str(bundle_path),
-                    "-o",
-                    f"{bundle_path}.mzip",
-                    "-clean-meta",
-                    "-f",
+                    "java", "-jar", str(apkeditor_jar), "merge",
+                    "-i", str(bundle_path), "-o", f"{bundle_path}.mzip",
+                    "-clean-meta", "-f",
                 ],
                 capture_output=True,
                 text=True,
@@ -440,23 +229,12 @@ class APKMirror(ScraperBase):
 
         extract_dir = bundle_path.with_suffix("")
         extract_dir.mkdir(exist_ok=True)
-
         subprocess.run(["unzip", "-qo", f"{bundle_path}.mzip", "-d", str(extract_dir)], check=True)
-
         zip_path = bundle_path.with_suffix(".zip")
-        subprocess.run(
-            ["zip", "-0rq", str(zip_path), "."],
-            cwd=extract_dir,
-            check=True,
-        )
-
-        import shutil
-
+        subprocess.run(["zip", "-0rq", str(zip_path), "."], cwd=extract_dir, check=True)
         shutil.move(str(zip_path), str(output_path))
-
         for cleanup in (extract_dir, bundle_path.with_suffix(".mzip")):
             shutil.rmtree(cleanup, ignore_errors=True)
-
         return True
 
     async def download(
@@ -469,133 +247,78 @@ class APKMirror(ScraperBase):
         bundle_type: BundleType = "APK",
         exclude_alpha_beta: bool = True,
     ) -> DownloadResult:
-        """Download a specific version from APKMirror.
-
-        Args:
-            pkg_name: Package name (app identifier).
-            version: Version to download (None for latest).
-            output_path: Path to save the downloaded file.
-            arch: Target architecture (default: universal).
-            dpi: Screen DPI filter (default: nodpi).
-            bundle_type: Bundle type - APK or BUNDLE (default: APK).
-            exclude_alpha_beta: Exclude alpha/beta versions (default: True).
-
-        Returns:
-            DownloadResult with success status, file path, and version.
-
-        """
         config = SearchConfig(
             apk_bundle=bundle_type,
             dpi=dpi,
             arch=arch,
             exclude_alpha_beta=exclude_alpha_beta,
         )
-
         try:
             if version is None:
                 versions = await self.get_versions(
-                    pkg_name=pkg_name,
-                    arch=arch,
-                    dpi=dpi,
-                    bundle_type=bundle_type,
-                    exclude_alpha_beta=exclude_alpha_beta,
+                    pkg_name=pkg_name, arch=arch, dpi=dpi,
+                    bundle_type=bundle_type, exclude_alpha_beta=exclude_alpha_beta,
                 )
                 if not versions:
-                    return DownloadResult(
-                        success=False,
-                        error="No versions found",
-                    )
+                    return DownloadResult(success=False, error="No versions found")
                 version_info = versions[0]
                 download_url = version_info.url
                 version = version_info.version
             else:
                 versions_url = self._get_versions_page_url(pkg_name)
-                response = await asyncio.to_thread(self.get, versions_url)
-
+                response = await self.get(versions_url)
                 tree = HTMLParser(response.text)
                 version_links = tree.css("div.version-fed-list > div")
-
                 download_url = None
                 for link_container in version_links:
                     link = link_container.css_first("a")
                     if link is None:
                         continue
-
                     href = link.attrs.get("href")
                     if not href:
                         continue
-
                     version_text = link.css_first("span")
                     version_str = version_text.text() if version_text else ""
-
                     if version_str.strip() != version:
                         continue
-
                     if exclude_alpha_beta and ("alpha" in version_str.lower() or "beta" in version_str.lower()):
                         continue
-
                     variant_url = f"{self.BASE_URL}{href}"
-
-                    variant_html = await asyncio.to_thread(self.get, variant_url, False)
-
+                    variant_html = await self.get(variant_url, False)
                     download_url = self._search_variant(variant_html.text, config)
                     break
-
                 if download_url is None:
                     return DownloadResult(
                         success=False,
                         error=f"Version {version} not found with specified criteria",
                     )
 
-            final_download_url = await asyncio.get_event_loop().run_in_executor(
-                None, self._get_download_url, download_url
-            )
+            final_download_url = await self._get_download_url(download_url)
             if final_download_url is None:
-                return DownloadResult(
-                    success=False,
-                    error="Failed to get download URL",
-                )
+                return DownloadResult(success=False, error="Failed to get download URL")
 
-            await asyncio.to_thread(self._download_file, final_download_url, output_path)
+            await self._download_file(final_download_url, output_path)
 
             if self._is_bundle(output_path):
                 merged_path = output_path.with_suffix(".apk")
                 await asyncio.to_thread(self._merge_splits, output_path, merged_path)
                 output_path = merged_path
 
-            return DownloadResult(
-                success=True,
-                file_path=output_path,
-                version=version,
-            )
+            return DownloadResult(success=True, file_path=output_path, version=version)
 
         except Exception as e:
-            return DownloadResult(
-                success=False,
-                error=str(e),
-            )
+            return DownloadResult(success=False, error=str(e))
 
-    def _download_file(self, url: str, output_path: Path) -> None:
-        """Download a file from URL to output path.
-
-        Args:
-            url: Download URL.
-            output_path: Path to save the file.
-
-        """
-        response = self.get(url, use_cache=False)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(response.content)
+    async def _download_file(self, url: str, output_path: Path) -> None:
+        response = await self.get(url, use_cache=False)
+        await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(output_path.write_bytes, response.content)
 
     def close(self) -> None:
-        """Close the scraper and clean up resources."""
         super().close()
         if self._temp_dir is not None:
-            import shutil
-
             shutil.rmtree(self._temp_dir, ignore_errors=True)
             self._temp_dir = None
 
     def __del__(self) -> None:
-        """Destructor to ensure cleanup."""
         self.close()

--- a/scripts/scrapers/apkmonk.py
+++ b/scripts/scrapers/apkmonk.py
@@ -32,34 +32,14 @@ class APKMonkScraper(ScraperBase):
         super().__init__(DownloadSource.APKMonk)
 
     def _build_url(self, package: str, path: str = "") -> str:
-        """Build APKMonk URL.
-
-        Args:
-            package: Package name.
-            path: Additional path suffix.
-
-        Returns:
-            Full URL path.
-
-        """
         base = f"{APKMONK_BASE}/app/{package}"
         if path:
             return f"{base}/{path}"
         return base
 
     def _parse_versions_page(self, html_content: str) -> list[VersionInfo]:
-        """Parse versions from APKMonk versions page.
-
-        Args:
-            html_content: HTML of the versions page.
-
-        Returns:
-            List of VersionInfo objects.
-
-        """
         tree = HTMLParser(html_content)
         versions: list[VersionInfo] = []
-
         for item in tree.css("div.version-content"):
             version_elem = item.css_first("span.version")
             version = version_elem.text(strip=True) if version_elem else None
@@ -67,7 +47,6 @@ class APKMonkScraper(ScraperBase):
                 download_elem = item.css_first("a.download-btn")
                 url = download_elem.attrs.get("href") if download_elem else None
                 versions.append(VersionInfo(version=version, url=url))
-
         for item in tree.css("div.related-ver-content"):
             version_elem = item.css_first("span.version")
             version = version_elem.text(strip=True) if version_elem else None
@@ -75,52 +54,26 @@ class APKMonkScraper(ScraperBase):
                 download_elem = item.css_first("a.download-btn")
                 url = download_elem.attrs.get("href") if download_elem else None
                 versions.append(VersionInfo(version=version, url=url))
-
         return versions
 
     def _parse_download_link(self, html_content: str) -> str | None:
-        """Extract download URL from APKMonk download page.
-
-        Args:
-            html_content: HTML of the download page.
-
-        Returns:
-            Download URL or None if not found.
-
-        """
         tree = HTMLParser(html_content)
-
         download_link = tree.css_first("a.download-link")
         if download_link is not None:
             href = download_link.attrs.get("href")
             if href:
                 return href.strip()
-
         download_btn = tree.css_first("div.download-btn a")
         if download_btn is not None:
             href = download_btn.attrs.get("href")
             if href:
                 return href.strip()
-
         return None
 
     async def get_versions(self, pkg_name: str, **kwargs: object) -> list[VersionInfo]:
-        """Get available versions for an app.
-
-        Args:
-            pkg_name: Package name (e.g., 'com.google.android.youtube').
-            name: App name slug (passed via kwargs, unused for APKMonk).
-
-        Returns:
-            List of VersionInfo objects.
-
-        """
         url = self._build_url(pkg_name)
-
-        loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(None, self.get, url)
+        response = await self.get(url)
         html = response.text
-
         return self._parse_versions_page(html)
 
     async def download(
@@ -130,80 +83,39 @@ class APKMonkScraper(ScraperBase):
         output_path: Path,
         **kwargs: object,
     ) -> DownloadResult:
-        """Download specific version of an app.
-
-        Args:
-            pkg_name: Package name.
-            version: Version string to download.
-            output_path: Path to save the APK.
-            name: App name slug (passed via kwargs, unused for APKMonk).
-
-        Returns:
-            DownloadResult with success status and file path.
-
-        """
         if version is None:
             return DownloadResult(success=False, error="Version is required")
 
         url = self._build_url(pkg_name, f"download/{version}")
 
-        loop = asyncio.get_event_loop()
-
         try:
-            response = await loop.run_in_executor(None, self.get, url)
+            response = await self.get(url)
             html = response.text
-
             download_url = self._parse_download_link(html)
             if download_url is None:
                 return DownloadResult(success=False, error="Download link not found")
 
-            dl_response = await loop.run_in_executor(None, self._request_with_retry, download_url, "GET")
-
+            dl_response = await self._request_with_retry(download_url, "GET")
             content_type = dl_response.headers.get("content-type", "")
             if "text/html" in content_type.lower():
                 download_url = self._parse_download_link(dl_response.text)
                 if download_url is None:
                     return DownloadResult(success=False, error="Download link not found")
-                dl_response = await loop.run_in_executor(None, self._request_with_retry, download_url, "GET")
+                dl_response = await self._request_with_retry(download_url, "GET")
 
-            await loop.run_in_executor(
-                None,
-                self._save_apk,
-                dl_response,
-                output_path,
-            )
+            await asyncio.to_thread(self._save_apk, dl_response, output_path)
 
-            return DownloadResult(
-                success=True,
-                file_path=output_path,
-                version=version,
-            )
+            return DownloadResult(success=True, file_path=output_path, version=version)
 
         except Exception as e:
             return DownloadResult(success=False, error=str(e))
 
     def _save_apk(self, response: httpx.Response, output_path: Path) -> None:
-        """Save APK from response to file.
-
-        Args:
-            response: HTTP response object.
-            output_path: Path to save the APK.
-
-        """
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with output_path.open("wb") as f:
             f.writelines(response.iter_bytes(chunk_size=8192))
 
     def get_package_name(self, url: str) -> str | None:
-        """Extract package name from APKMonk URL.
-
-        Args:
-            url: APKMonk URL in format https://www.apkmonk.com/app/{package}/.
-
-        Returns:
-            Package name if found, None otherwise.
-
-        """
         pattern = r"apkmonk\.com/app/([a-zA-Z0-9_.]+)"
         match = re.search(pattern, url)
         if match:

--- a/scripts/scrapers/apkpure.py
+++ b/scripts/scrapers/apkpure.py
@@ -1,8 +1,4 @@
-"""APKPure scraper implementation.
-
-Inherits from ScraperBase and provides async methods for fetching
-versions and downloading APKs from APKPure.
-"""
+"""APKPure scraper implementation."""
 
 from __future__ import annotations
 
@@ -32,95 +28,47 @@ class APKPureScraper(ScraperBase):
         super().__init__(DownloadSource.APKPURE)
 
     def _build_url(self, name: str, package: str, path: str = "") -> str:
-        """Build APKPure URL.
-
-        Args:
-            name: App name slug on APKPure.
-            package: Android package name.
-            path: Additional path suffix.
-
-        Returns:
-            Full URL path.
-
-        """
         base = f"{APKPURE_BASE}/{name}/{package}"
         if path:
             return f"{base}/{path}"
         return base
 
     def _parse_versions_page(self, html_content: str) -> list[VersionInfo]:
-        """Parse versions from APKPure versions page.
-
-        Args:
-            html_content: HTML of the versions page.
-
-        Returns:
-            List of VersionInfo objects.
-
-        """
         tree = HTMLParser(html_content)
         versions: list[VersionInfo] = []
         seen: set[str] = set()
-
         for item in tree.css("div.ver-item a span.ver-item-n"):
             text = item.text(strip=True)
             if text and text not in seen:
                 seen.add(text)
                 versions.append(VersionInfo(version=text))
-
         if not versions:
             ver_top = tree.css_first("div.ver-top-down")
             if ver_top is not None:
                 dt_version = ver_top.attrs.get("data-dt-version")
                 if dt_version and (version := dt_version.strip()):
                     versions.append(VersionInfo(version=version))
-
         return versions
 
     def _parse_download_link(self, html_content: str) -> str | None:
-        """Extract download URL from APKPure download page.
-
-        Args:
-            html_content: HTML of the download page.
-
-        Returns:
-            Download URL or None if not found.
-
-        """
         tree = HTMLParser(html_content)
-
         link = tree.css_first("a#download_link")
         if link is not None:
             href = link.attrs.get("href")
             if href:
                 return href.strip()
-
         link = tree.css_first("a.da")
         if link is not None:
             href = link.attrs.get("href")
             if href:
                 return href.strip()
-
         return None
 
     async def get_versions(self, pkg_name: str, **kwargs: object) -> list[VersionInfo]:
-        """Get available versions for an app.
-
-        Args:
-            pkg_name: Package name (e.g., 'com.google.android.youtube').
-            name: App name slug (passed via kwargs).
-
-        Returns:
-            List of VersionInfo objects.
-
-        """
         name = str(kwargs.get("name", pkg_name))
         url = self._build_url(name, pkg_name, "versions")
-
-        loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(None, self.get, url)
+        response = await self.get(url)
         html = response.text
-
         return self._parse_versions_page(html)
 
     async def download(
@@ -130,82 +78,41 @@ class APKPureScraper(ScraperBase):
         output_path: Path,
         **kwargs: object,
     ) -> DownloadResult:
-        """Download specific version of an app.
-
-        Args:
-            pkg_name: Package name.
-            version: Version string to download.
-            output_path: Path to save the APK.
-            name: App name slug (passed via kwargs).
-
-        Returns:
-            DownloadResult with success status and file path.
-
-        """
         if version is None:
             return DownloadResult(success=False, error="Version is required")
 
         name = str(kwargs.get("name", pkg_name))
         url = self._build_url(name, pkg_name, f"download/{version}")
 
-        loop = asyncio.get_event_loop()
-
         try:
-            response = await loop.run_in_executor(None, self.get, url)
+            response = await self.get(url)
             html = response.text
-
             download_url = self._parse_download_link(html)
             if download_url is None:
                 return DownloadResult(success=False, error="Download link not found")
 
-            dl_response = await loop.run_in_executor(None, self._request_with_retry, download_url, "GET")
-
+            dl_response = await self._request_with_retry(download_url, "GET")
             content_type = dl_response.headers.get("content-type", "")
             if "text/html" in content_type.lower():
                 html = dl_response.text
                 download_url = self._parse_download_link(html)
                 if download_url is None:
                     return DownloadResult(success=False, error="Download link not found")
-                dl_response = await loop.run_in_executor(None, self._request_with_retry, download_url, "GET")
+                dl_response = await self._request_with_retry(download_url, "GET")
 
-            await loop.run_in_executor(
-                None,
-                self._save_apk,
-                dl_response,
-                output_path,
-            )
+            await asyncio.to_thread(self._save_apk, dl_response, output_path)
 
-            return DownloadResult(
-                success=True,
-                file_path=output_path,
-                version=version,
-            )
+            return DownloadResult(success=True, file_path=output_path, version=version)
 
         except Exception as e:
             return DownloadResult(success=False, error=str(e))
 
     def _save_apk(self, response: httpx.Response, output_path: Path) -> None:
-        """Save APK from response to file.
-
-        Args:
-            response: HTTP response object.
-            output_path: Path to save the APK.
-
-        """
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with output_path.open("wb") as f:
             f.writelines(response.iter_bytes(chunk_size=8192))
 
     def get_package_name(self, url: str) -> str | None:
-        """Extract package name from APKPure URL.
-
-        Args:
-            url: APKPure URL in format https://apkpure.net/{name}/{package}.
-
-        Returns:
-            Package name if found, None otherwise.
-
-        """
         pattern = r"apkpure\.net/[^/]+/([a-zA-Z0-9_.]+)"
         match = re.search(pattern, url)
         if match:

--- a/scripts/scrapers/aptoide.py
+++ b/scripts/scrapers/aptoide.py
@@ -1,8 +1,4 @@
-"""Aptoide scraper implementation.
-
-Inherits from ScraperBase and provides async methods for fetching
-versions and downloading APKs from Aptoide.
-"""
+"""Aptoide scraper implementation."""
 
 from __future__ import annotations
 
@@ -39,39 +35,12 @@ class AptoideScraper(ScraperBase):
         super().__init__(DownloadSource.APTOIDE)
 
     def _build_info_url(self, package: str) -> str:
-        """Build Aptoide app info URL.
-
-        Args:
-            package: Android package name.
-
-        Returns:
-            API URL for app info.
-
-        """
         return f"{APTOIDE_API}/app/{package}/getInfo"
 
     def _build_versions_url(self, package: str) -> str:
-        """Build Aptoide versions URL.
-
-        Args:
-            package: Android package name.
-
-        Returns:
-            API URL for versions.
-
-        """
         return f"{APTOIDE_API}/app/{package}/getVersions"
 
     def _parse_version_info(self, data: dict) -> list[VersionInfo]:
-        """Parse version info from Aptoide API response.
-
-        Args:
-            data: JSON response from Aptoide API.
-
-        Returns:
-            List of VersionInfo objects.
-
-        """
         versions: list[VersionInfo] = []
         versions_list = data.get("data", {}).get("versions", [])
         for item in versions_list:
@@ -81,55 +50,22 @@ class AptoideScraper(ScraperBase):
             apk_files = item.get("file", {})
             path = apk_files.get("path")
             arch = item.get("architecture")
-            versions.append(
-                VersionInfo(
-                    version=version,
-                    url=path,
-                    arch=arch,
-                )
-            )
+            versions.append(VersionInfo(version=version, url=path, arch=arch))
         return versions
 
-    def _filter_by_architecture(
-        self,
-        versions: list[VersionInfo],
-        arch: str,
-    ) -> list[VersionInfo]:
-        """Filter versions by architecture.
-
-        Args:
-            versions: List of VersionInfo objects.
-            arch: Target architecture.
-
-        Returns:
-            Filtered list of VersionInfo objects.
-
-        """
+    def _filter_by_architecture(self, versions: list[VersionInfo], arch: str) -> list[VersionInfo]:
         if arch == "universal":
             return versions
         return [v for v in versions if v.arch == arch or v.arch == "universal"]
 
     async def get_versions(self, pkg_name: str, **kwargs: object) -> list[VersionInfo]:
-        """Get available versions for an app.
-
-        Args:
-            pkg_name: Package name (e.g., 'com.google.android.youtube').
-            arch: Architecture filter (optional).
-
-        Returns:
-            List of VersionInfo objects.
-
-        """
         url = self._build_versions_url(pkg_name)
-        loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(None, self.get, url)
+        response = await self.get(url)
         data = response.json()
         versions = self._parse_version_info(data)
-
         arch = str(kwargs.get("arch", "universal"))
         if arch and arch != "universal":
             versions = self._filter_by_architecture(versions, arch)
-
         return versions
 
     async def download(
@@ -139,18 +75,6 @@ class AptoideScraper(ScraperBase):
         output_path: Path,
         **kwargs: object,
     ) -> DownloadResult:
-        """Download specific version of an app.
-
-        Args:
-            pkg_name: Package name.
-            version: Version string to download.
-            output_path: Path to save the APK.
-            arch: Architecture filter (optional).
-
-        Returns:
-            DownloadResult with success status and file path.
-
-        """
         if version is None:
             return DownloadResult(success=False, error="Version is required")
 
@@ -165,56 +89,25 @@ class AptoideScraper(ScraperBase):
 
         if target_version is None:
             return DownloadResult(success=False, error=f"Version {version} not found")
-
         if target_version.url is None:
             return DownloadResult(success=False, error="Download URL not available")
 
-        loop = asyncio.get_event_loop()
         try:
-            dl_response = await loop.run_in_executor(None, self._request_with_retry, target_version.url, "GET")
-
+            dl_response = await self._request_with_retry(target_version.url, "GET")
             content_type = dl_response.headers.get("content-type", "")
             if "text/html" in content_type.lower():
                 return DownloadResult(success=False, error="Received HTML instead of APK")
-
-            await loop.run_in_executor(
-                None,
-                self._save_apk,
-                dl_response,
-                output_path,
-            )
-
-            return DownloadResult(
-                success=True,
-                file_path=output_path,
-                version=version,
-            )
-
+            await asyncio.to_thread(self._save_apk, dl_response, output_path)
+            return DownloadResult(success=True, file_path=output_path, version=version)
         except Exception as e:
             return DownloadResult(success=False, error=str(e))
 
     def _save_apk(self, response: httpx.Response, output_path: Path) -> None:
-        """Save APK from response to file.
-
-        Args:
-            response: HTTP response object.
-            output_path: Path to save the APK.
-
-        """
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with output_path.open("wb") as f:
             f.writelines(response.iter_bytes(chunk_size=8192))
 
     def get_package_name(self, url: str) -> str | None:
-        """Extract package name from Aptoide URL.
-
-        Args:
-            url: Aptoide URL in format https://{subdomain}.aptoide.com/{package}.
-
-        Returns:
-            Package name if found, None otherwise.
-
-        """
         pattern = r"aptoide\.com/([a-zA-Z0-9_.]+)"
         match = re.search(pattern, url)
         if match:

--- a/scripts/scrapers/archive.py
+++ b/scripts/scrapers/archive.py
@@ -37,30 +37,24 @@ class ArchiveScraper(ScraperBase):
 
     async def get_versions(self, pkg_name: str, **kwargs: object) -> list[VersionInfo]:
         url = f"{ARCHIVE_BASE_URL}/{pkg_name}"
-        response = await asyncio.to_thread(self.get, url)
+        response = await self.get(url)
         parser = HTMLParser(response.text)
-
         versions: list[VersionInfo] = []
         seen: set[str] = set()
-
         for link in parser.css("a"):
             href = link.attributes.get("href", "")
             if not href or href.startswith("?") or "/" not in href:
                 continue
-
             filename = href.rstrip("/").split("/")[-1]
             if not filename.endswith(".apk"):
                 continue
-
             parsed = self._parse_filename(filename)
             if parsed is None:
                 continue
-
             version_key = f"{parsed.version}-{parsed.arch}"
             if version_key in seen:
                 continue
             seen.add(version_key)
-
             versions.append(
                 VersionInfo(
                     version=parsed.version,
@@ -68,7 +62,6 @@ class ArchiveScraper(ScraperBase):
                     arch=parsed.arch,
                 )
             )
-
         versions.sort(
             key=lambda v: [int(x) if x.isdigit() else x for x in v.version.split(".")],
             reverse=True,
@@ -80,11 +73,7 @@ class ArchiveScraper(ScraperBase):
         match: Match[str] | None = self.VERSION_PATTERN.match(name_without_ext)
         if not match:
             return None
-
-        return VersionInfo(
-            version=match.group("version"),
-            arch=match.group("arch"),
-        )
+        return VersionInfo(version=match.group("version"), arch=match.group("arch"))
 
     async def download(
         self,
@@ -94,51 +83,20 @@ class ArchiveScraper(ScraperBase):
         **kwargs: object,
     ) -> DownloadResult:
         arch: str | None = kwargs.get("arch")
-
         if version is None:
-            return DownloadResult(
-                success=False,
-                error="Version is required for Archive.org downloads",
-            )
-
+            return DownloadResult(success=False, error="Version is required for Archive.org downloads")
         versions = await self.get_versions(pkg_name, **kwargs)
-
         for v in versions:
             if v.version == version and (arch is None or v.arch == arch):
-                loop = asyncio.get_running_loop()
-                return await loop.run_in_executor(
-                    None,
-                    self._download_file,
-                    v.url,
-                    output_path,
-                    v.version,
-                )
+                return await self._download_file(v.url, output_path, v.version)
+        return DownloadResult(success=False, error=f"Version {version} not found for package {pkg_name}")
 
-        return DownloadResult(
-            success=False,
-            error=f"Version {version} not found for package {pkg_name}",
-        )
-
-    def _download_file(
-        self,
-        url: str,
-        output_path: Path,
-        version: str,
-    ) -> DownloadResult:
+    async def _download_file(self, url: str, output_path: Path, version: str) -> DownloadResult:
         try:
-            response = self.session.get(url, follow_redirects=True)
+            response = await self.session.get(url, follow_redirects=True)
             response.raise_for_status()
-
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_bytes(response.content)
-
-            return DownloadResult(
-                success=True,
-                file_path=output_path,
-                version=version,
-            )
+            await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
+            await asyncio.to_thread(output_path.write_bytes, response.content)
+            return DownloadResult(success=True, file_path=output_path, version=version)
         except Exception as e:
-            return DownloadResult(
-                success=False,
-                error=str(e),
-            )
+            return DownloadResult(success=False, error=str(e))

--- a/scripts/scrapers/base.py
+++ b/scripts/scrapers/base.py
@@ -1,5 +1,6 @@
 """Base scraper class and common types for all APK download sources."""
 
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -42,13 +43,13 @@ class ScraperBase(ABC):
 
     def __init__(self, source: DownloadSource) -> None:
         self.source = source
-        self._session: httpx.Client | None = None
+        self._session: httpx.AsyncClient | None = None
         self._cache: dict[str, tuple[float, object]] = {}
 
     @property
-    def session(self) -> httpx.Client:
+    def session(self) -> httpx.AsyncClient:
         if self._session is None:
-            self._session = httpx.Client(
+            self._session = httpx.AsyncClient(
                 timeout=30.0,
                 follow_redirects=True,
                 headers={
@@ -71,7 +72,7 @@ class ScraperBase(ABC):
     def _clear_cache(self) -> None:
         self._cache.clear()
 
-    def _request_with_retry(
+    async def _request_with_retry(
         self,
         url: str,
         method: str = "GET",
@@ -82,26 +83,26 @@ class ScraperBase(ABC):
 
         for attempt in range(self.MAX_RETRIES):
             try:
-                response = self.session.request(method, url, **kwargs)
+                response = await self.session.request(method, url, **kwargs)
                 response.raise_for_status()
                 return response
             except (httpx.HTTPError, httpx.TimeoutException) as e:
                 last_error = e
                 if attempt < self.MAX_RETRIES - 1:
-                    _time.sleep(delay)
+                    await asyncio.sleep(delay)
                     delay *= 2
 
         msg = f"Request failed after {self.MAX_RETRIES} retries: {url}"
         raise RuntimeError(msg) from last_error
 
-    def get(self, url: str, use_cache: bool = True) -> httpx.Response:
+    async def get(self, url: str, use_cache: bool = True) -> httpx.Response:
         cache_key = f"get:{url}"
         if use_cache:
             cached = self._get_cache(cache_key)
             if cached is not None:
                 return cached  # type: ignore[return-value]
 
-        response = self._request_with_retry(url)
+        response = await self._request_with_retry(url)
         if use_cache:
             self._set_cache(cache_key, response)
         return response
@@ -124,7 +125,12 @@ class ScraperBase(ABC):
 
     def close(self) -> None:
         if self._session is not None:
-            self._session.close()
+            try:
+                loop = asyncio.get_running_loop()
+                task = loop.create_task(self._session.aclose())
+                del task
+            except RuntimeError:
+                pass
             self._session = None
 
     def __del__(self) -> None:

--- a/scripts/scrapers/uptodown.py
+++ b/scripts/scrapers/uptodown.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import re
-import time
 import zipfile
 from dataclasses import dataclass
 from io import BytesIO
@@ -41,17 +40,6 @@ XAPK_MIME_TYPES = frozenset(
 
 @dataclass
 class UptodownVersion:
-    """Represents an Uptodown version entry.
-
-    Attributes:
-        version: Version string.
-        url: Download URL.
-        arch: Target architecture (None for universal).
-        file_id: Uptodown file ID.
-        is_xapk: Whether the file is an XAPK bundle.
-
-    """
-
     version: str
     url: str | None
     arch: str | None
@@ -60,39 +48,14 @@ class UptodownVersion:
 
 
 class UptodownScraper(ScraperBase):
-    """Uptodown scraper for Android APK version lookup and downloads.
-
-    Provides async methods for fetching available versions and downloading
-    specific APK versions from Uptodown's Android app repository.
-
-    Attributes:
-        source: Download source identifier (UPTODOWN).
-        base_url: Base URL template for Uptodown app pages.
-        max_pages: Maximum number of pages to search for versions.
-
-    Example:
-        >>> scraper = UptodownScraper()
-        >>> versions = await scraper.get_versions("youtube")
-        >>> result = await scraper.download("youtube", versions[0].version, Path("out.apk"))
-
-    """
+    """Uptodown scraper for Android APK version lookup and downloads."""
 
     def __init__(self) -> None:
-        """Initialize Uptodown scraper."""
         super().__init__(DownloadSource.UPTODOWN)
         self.base_url = "https://{app}.en.uptodown.com/android"
         self.max_pages = 5
 
     def get_package_name(self, url: str) -> str | None:
-        """Extract package/app name from Uptodown URL.
-
-        Args:
-            url: Uptodown URL in format https://{app}.en.uptodown.com/android
-
-        Returns:
-            App name if found, None otherwise.
-
-        """
         pattern = r"https://([^.]+)\.en\.uptodown\.com/android"
         match = re.match(pattern, url)
         if match:
@@ -100,75 +63,34 @@ class UptodownScraper(ScraperBase):
         return None
 
     def _build_app_url(self, app: str) -> str:
-        """Build the base app page URL.
-
-        Args:
-            app: App/package name.
-
-        Returns:
-            Full Uptodown URL for the app.
-
-        """
         return self.base_url.format(app=app)
 
     def _build_version_page_url(self, app: str, page: int) -> str:
-        """Build URL for a specific version page.
-
-        Args:
-            app: App/package name.
-            page: Page number (1-indexed).
-
-        Returns:
-            URL for the version listing page.
-
-        """
         base = self._build_app_url(app)
         return f"{base}/versions/page/{page}"
 
     async def _fetch_page(self, url: str) -> str | None:
-        """Fetch a page with retry logic.
-
-        Args:
-            url: URL to fetch.
-
-        Returns:
-            Page HTML content or None if fetch failed.
-
-        """
         try:
-            response = await asyncio.to_thread(self.get, url)
+            response = await self.get(url)
         except Exception:
             return None
         else:
             return response.text
 
     def _parse_version_card(self, node: Node) -> UptodownVersion | None:
-        """Parse a version card node to extract version info.
-
-        Args:
-            node: selectolax Node for the version card.
-
-        Returns:
-            UptodownVersion if parsing succeeded, None otherwise.
-
-        """
         try:
             version_link = node.css_first("a.version-detail")
             if version_link is None:
                 return None
-
             version = version_link.text(strip=True)
-
             href = version_link.attrs.get("href", "")
             file_id_match = re.search(r"/download/([^/]+)", href)
             file_id = file_id_match.group(1) if file_id_match else ""
-
             file_type = node.css_first("span.file-type")
             is_xapk = False
             if file_type:
                 type_text = file_type.text(strip=True).lower()
                 is_xapk = "xapk" in type_text or "bundle" in type_text
-
             arch_elem = node.css_first("p:last-child")
             arch: str | None = None
             if arch_elem:
@@ -177,7 +99,6 @@ class UptodownScraper(ScraperBase):
                     if supported in arch_text:
                         arch = supported
                         break
-
             return UptodownVersion(
                 version=version,
                 url=href if href.startswith("http") else f"https://en.uptodown.com{href}",
@@ -189,15 +110,6 @@ class UptodownScraper(ScraperBase):
             return None
 
     def _parse_versions_page(self, html: str) -> list[UptodownVersion]:
-        """Parse HTML content for version entries.
-
-        Args:
-            html: HTML content of versions page.
-
-        Returns:
-            List of parsed UptodownVersion objects.
-
-        """
         versions: list[UptodownVersion] = []
         with contextlib.suppress(Exception):
             tree = HTMLParser(html)
@@ -209,53 +121,28 @@ class UptodownScraper(ScraperBase):
         return versions
 
     async def get_versions(self, pkg_name: str, **kwargs: object) -> list[VersionInfo]:
-        """Get available versions for an app.
-
-        Searches pages 1-5 for version listings and returns all found versions.
-
-        Args:
-            pkg_name: Package/app name for Uptodown URL.
-            **kwargs: Additional arguments (arch filter if provided).
-
-        Returns:
-            List of VersionInfo objects with available versions.
-
-        """
         target_arch: str | None = kwargs.get("arch")
         all_versions: list[UptodownVersion] = []
-
         for page in range(1, self.max_pages + 1):
             url = self._build_version_page_url(pkg_name, page)
             html = await self._fetch_page(url)
-
             if not html:
                 await asyncio.sleep(0.5)
                 continue
-
             page_versions = self._parse_versions_page(html)
             if not page_versions:
                 break
-
             all_versions.extend(page_versions)
             await asyncio.sleep(0.3)
-
         if target_arch and target_arch in SUPPORTED_ARCHS:
             all_versions = [v for v in all_versions if v.arch == target_arch or v.arch is None]
-
         result: list[VersionInfo] = []
         seen: set[str] = set()
         for v in all_versions:
             if v.version in seen:
                 continue
             seen.add(v.version)
-            result.append(
-                VersionInfo(
-                    version=v.version,
-                    url=v.url,
-                    arch=v.arch,
-                )
-            )
-
+            result.append(VersionInfo(version=v.version, url=v.url, arch=v.arch))
         return result
 
     async def _resolve_target_version(
@@ -264,17 +151,6 @@ class UptodownScraper(ScraperBase):
         version: str,
         target_arch: str | None,
     ) -> UptodownVersion | None:
-        """Resolve UptodownVersion from version string and arch.
-
-        Args:
-            pkg_name: Package name.
-            version: Version string.
-            target_arch: Target architecture.
-
-        Returns:
-            UptodownVersion if found, None otherwise.
-
-        """
         versions = await self.get_versions(pkg_name, arch=target_arch)
         for v_info in versions:
             if v_info.version == version and v_info.url:
@@ -283,11 +159,8 @@ class UptodownScraper(ScraperBase):
                     if fv.version == version:
                         return fv
                 return UptodownVersion(
-                    version=version,
-                    url=v_info.url,
-                    arch=v_info.arch,
-                    file_id="",
-                    is_xapk=False,
+                    version=version, url=v_info.url, arch=v_info.arch,
+                    file_id="", is_xapk=False,
                 )
         return None
 
@@ -298,18 +171,6 @@ class UptodownScraper(ScraperBase):
         output_path: Path,
         **kwargs: object,
     ) -> DownloadResult:
-        """Download a specific version.
-
-        Args:
-            pkg_name: Package/app name.
-            version: Version to download (None for latest).
-            output_path: Path where APK should be saved.
-            **kwargs: Additional arguments (arch preference).
-
-        Returns:
-            DownloadResult with success status and file path or error.
-
-        """
         target_arch = kwargs.get("arch")
         if target_arch is not None:
             target_arch = str(target_arch) or None
@@ -317,82 +178,39 @@ class UptodownScraper(ScraperBase):
         if version is None:
             versions = await self.get_versions(pkg_name, arch=target_arch)
             if not versions:
-                return DownloadResult(
-                    success=False,
-                    file_path=None,
-                    version=None,
-                    error="No versions found",
-                )
+                return DownloadResult(success=False, file_path=None, version=None, error="No versions found")
             version = versions[0].version
 
         target_version = await self._resolve_target_version(pkg_name, version, target_arch)
 
         if target_version is None or not target_version.url:
-            return DownloadResult(
-                success=False,
-                file_path=None,
-                version=version,
-                error=f"Version {version} not found",
-            )
+            return DownloadResult(success=False, file_path=None, version=version, error=f"Version {version} not found")
 
         try:
-            response = await asyncio.to_thread(self._request_with_retry, target_version.url)
+            response = await self._request_with_retry(target_version.url)
             content = response.content
-
             if target_version.is_xapk:
                 return await self._download_xapk(content, output_path, version)
-
             await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
             await asyncio.to_thread(output_path.write_bytes, content)
-
-            return DownloadResult(
-                success=True,
-                file_path=output_path,
-                version=version,
-                error=None,
-            )
+            return DownloadResult(success=True, file_path=output_path, version=version, error=None)
         except Exception as e:
             log.error(f"Download failed: {e}")
-            return DownloadResult(
-                success=False,
-                file_path=None,
-                version=version,
-                error=str(e),
-            )
+            return DownloadResult(success=False, file_path=None, version=version, error=str(e))
 
-    async def _find_version_by_file_id(
-        self,
-        pkg_name: str,
-        arch: str | None,
-    ) -> list[UptodownVersion]:
-        """Find all versions matching an architecture.
-
-        Args:
-            pkg_name: Package/app name.
-            arch: Architecture to filter by.
-
-        Returns:
-            List of UptodownVersion objects matching the architecture.
-
-        """
+    async def _find_version_by_file_id(self, pkg_name: str, arch: str | None) -> list[UptodownVersion]:
         all_versions: list[UptodownVersion] = []
-
         for page in range(1, self.max_pages + 1):
             url = self._build_version_page_url(pkg_name, page)
             html = await self._fetch_page(url)
-
             if not html:
                 await asyncio.sleep(0.5)
                 continue
-
             page_versions = self._parse_versions_page(html)
             if not page_versions:
                 break
-
             all_versions.extend(v for v in page_versions if arch is None or v.arch == arch or v.arch is None)
-
             await asyncio.sleep(0.3)
-
         return all_versions
 
     async def _download_xapk(
@@ -401,87 +219,35 @@ class UptodownScraper(ScraperBase):
         output_path: Path,
         version: str | None,
     ) -> DownloadResult:
-        """Handle XAPK bundle download.
-
-        XAPK files are ZIP archives containing APK files. This method extracts
-        and saves the main APK.
-
-        Args:
-            content: XAPK file content.
-            output_path: Path where APK should be saved.
-            version: Version string for result.
-
-        Returns:
-            DownloadResult with success status.
-
-        """
         try:
             with zipfile.ZipFile(BytesIO(content)) as zf:
                 namelist = zf.namelist()
                 apk_files = [n for n in namelist if n.endswith(".apk")]
-
                 if not apk_files:
-                    return DownloadResult(
-                        success=False,
-                        file_path=None,
-                        version=version,
-                        error="No APK found in XAPK bundle",
-                    )
-
+                    return DownloadResult(success=False, file_path=None, version=version, error="No APK found in XAPK bundle")
                 main_apk = apk_files[0]
                 apk_content = await asyncio.to_thread(zf.read, main_apk)
-
                 await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
                 await asyncio.to_thread(output_path.write_bytes, apk_content)
-
-                return DownloadResult(
-                    success=True,
-                    file_path=output_path,
-                    version=version,
-                    error=None,
-                )
+                return DownloadResult(success=True, file_path=output_path, version=version, error=None)
         except zipfile.BadZipFile:
-            return DownloadResult(
-                success=False,
-                file_path=None,
-                version=version,
-                error="Invalid XAPK file format",
-            )
+            return DownloadResult(success=False, file_path=None, version=version, error="Invalid XAPK file format")
         except Exception as e:
-            return DownloadResult(
-                success=False,
-                file_path=None,
-                version=version,
-                error=f"XAPK extraction failed: {e}",
-            )
+            return DownloadResult(success=False, file_path=None, version=version, error=f"XAPK extraction failed: {e}")
 
-    def _request_with_retry(self, url: str) -> httpx.Response:
-        """Make HTTP request with retry logic.
-
-        Args:
-            url: URL to request.
-
-        Returns:
-            HTTP response.
-
-        Raises:
-            RuntimeError: If all retries fail.
-
-        """
+    async def _request_with_retry(self, url: str) -> httpx.Response:
         delay = self.BASE_DELAY
         last_error: Exception | None = None
-
         for attempt in range(self.MAX_RETRIES):
             try:
-                response = self.session.get(url)
+                response = await self.session.get(url)
                 response.raise_for_status()
             except Exception as e:
                 last_error = e
                 if attempt < self.MAX_RETRIES - 1:
-                    time.sleep(delay)
+                    await asyncio.sleep(delay)
                     delay *= 2
             else:
                 return response
-
         msg = f"Request failed after {self.MAX_RETRIES} retries: {url}"
         raise RuntimeError(msg) from last_error

--- a/scripts/utils/apk.py
+++ b/scripts/utils/apk.py
@@ -1,62 +1,37 @@
 """APK operations module for signing, aligning, and merging split APKs."""
 
+import logging
 import re
 import shutil
 import subprocess
-import tempfile
 import zipfile
 from enum import Enum
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class APKSigner:
     """APK signer with v1+v2 signature scheme enforcement."""
 
     def __init__(self, keystore: Path, keystore_password: str, key_alias: str, key_password: str) -> None:
-        """Initialize APKSigner with keystore credentials.
-
-        Args:
-            keystore: Path to the keystore file.
-            keystore_password: Password for the keystore.
-            key_alias: Alias of the key to use for signing.
-            key_password: Password for the key.
-        """
         self.keystore = keystore
         self.keystore_password = keystore_password
         self.key_alias = key_alias
         self.key_password = key_password
 
     def sign(self, input_path: Path, output_path: Path) -> bool:
-        """Sign an APK file with v1+v2 signature scheme.
-
-        Args:
-            input_path: Path to the input APK file.
-            output_path: Path to the output signed APK file.
-
-        Returns:
-            True if signing succeeded, False otherwise.
-        """
         cmd = [
-            "apksigner",
-            "sign",
-            "--ks",
-            str(self.keystore),
-            "--ks-pass",
-            f"pass:{self.keystore_password}",
-            "--key-pass",
-            f"pass:{self.key_password}",
-            "--ks-key-alias",
-            self.key_alias,
-            "--v1-signing-enabled",
-            "true",
-            "--v2-signing-enabled",
-            "true",
-            "--v3-signing-enabled",
-            "false",
-            "--v4-signing-enabled",
-            "false",
-            "--out",
-            str(output_path),
+            "apksigner", "sign",
+            "--ks", str(self.keystore),
+            "--ks-pass", f"pass:{self.keystore_password}",
+            "--key-pass", f"pass:{self.key_password}",
+            "--ks-key-alias", self.key_alias,
+            "--v1-signing-enabled", "true",
+            "--v2-signing-enabled", "true",
+            "--v3-signing-enabled", "false",
+            "--v4-signing-enabled", "false",
+            "--out", str(output_path),
             str(input_path),
         ]
         try:
@@ -67,15 +42,7 @@ class APKSigner:
 
 
 def _validate_path(path: Path, base_dir: Path | None = None) -> bool:
-    """Validate that a path does not contain path traversal attempts.
-
-    Args:
-        path: The path to validate.
-        base_dir: Optional base directory to check against.
-
-    Returns:
-        True if the path is safe, False otherwise.
-    """
+    """Validate that a path does not contain path traversal attempts."""
     try:
         resolved = path.resolve()
         if base_dir is not None:
@@ -87,15 +54,7 @@ def _validate_path(path: Path, base_dir: Path | None = None) -> bool:
 
 
 def _validate_apk_path(path: Path, purpose: str) -> None:
-    """Validate APK file path and extension.
-
-    Args:
-        path: The path to validate.
-        purpose: Description of the purpose for error messages.
-
-    Raises:
-        ValueError: If the path is invalid or has wrong extension.
-    """
+    """Validate APK file path and extension."""
     if not isinstance(path, Path):
         raise ValueError(f"{purpose}: path must be a Path object")
     if path.suffix.lower() != ".apk":
@@ -112,19 +71,7 @@ def sign_apk(
     key_alias: str,
     key_password: str,
 ) -> bool:
-    """Sign APK with v1+v2 scheme enforcement.
-
-    Args:
-        input_path: Path to the input APK file.
-        output_path: Path to the output signed APK file.
-        keystore: Path to the keystore file.
-        keystore_password: Password for the keystore.
-        key_alias: Alias of the key to use for signing.
-        key_password: Password for the key.
-
-    Returns:
-        True if signing succeeded, False otherwise.
-    """
+    """Sign APK with v1+v2 scheme enforcement."""
     _validate_apk_path(input_path, "sign_apk input")
     _validate_apk_path(output_path, "sign_apk output")
 
@@ -136,29 +83,14 @@ def sign_apk(
 
 
 def align_apk(input_path: Path, output_path: Path) -> bool:
-    """Zipalign APK to 4-byte alignment.
-
-    Args:
-        input_path: Path to the input APK file.
-        output_path: Path to the output aligned APK file.
-
-    Returns:
-        True if alignment succeeded, False otherwise.
-    """
+    """Zipalign APK to 4-byte alignment."""
     _validate_apk_path(input_path, "align_apk input")
     _validate_apk_path(output_path, "align_apk output")
 
     if not input_path.exists():
         return False
 
-    cmd = [
-        "zipalign",
-        "-f",
-        "-p",
-        "4",
-        str(input_path),
-        str(output_path),
-    ]
+    cmd = ["zipalign", "-f", "-p", "4", str(input_path), str(output_path)]
     try:
         subprocess.run(cmd, check=True, capture_output=True)
         return True
@@ -166,82 +98,14 @@ def align_apk(input_path: Path, output_path: Path) -> bool:
         return False
 
 
-def merge_bundle(bundle_path: Path, output_path: Path) -> bool:
-    """Merge split APK bundle into single APK using APKEditor.
-
-    Args:
-        bundle_path: Path to the XAPK/APKM bundle file.
-        output_path: Path to the output merged APK file.
-
-    Returns:
-        True if merge succeeded, False otherwise.
-    """
-    if not isinstance(bundle_path, Path):
-        raise ValueError("merge_bundle: bundle_path must be a Path object")
-    if not _validate_path(bundle_path):
-        raise ValueError(f"merge_bundle: path traversal detected in '{bundle_path}'")
-
-    bundle_ext = bundle_path.suffix.lower()
-    if bundle_ext not in (".xapk", ".apkm"):
-        raise ValueError(f"merge_bundle: bundle must be .xapk or .apkm, got '{bundle_ext}'")
-
-    if not _validate_path(output_path):
-        raise ValueError(f"merge_bundle: path traversal detected in '{output_path}'")
-    if output_path.suffix.lower() != ".apk":
-        raise ValueError("merge_bundle: output must have .apk extension")
-
-    if not bundle_path.exists():
-        return False
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-
-        try:
-            cmd = [
-                "java",
-                "-jar",
-                "APKEditor.jar",
-                "merge",
-                "-i",
-                str(bundle_path),
-                "-o",
-                str(temp_path / "merged.apk"),
-            ]
-            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-            if result.returncode != 0:
-                return False
-
-            merged_apk = temp_path / "merged.apk"
-            if not merged_apk.exists():
-                return False
-
-            shutil.copy2(merged_apk, output_path)
-            return True
-
-        except (subprocess.CalledProcessError, OSError):
-            return False
-
-
 def verify_signature(apk_path: Path) -> str | None:
-    """Get APK signature SHA256 for verification.
-
-    Args:
-        apk_path: Path to the APK file to verify.
-
-    Returns:
-        SHA256 hash of the APK signature certificate, or None if verification fails.
-    """
+    """Get APK signature SHA256 for verification."""
     _validate_apk_path(apk_path, "verify_signature")
 
     if not apk_path.exists():
         return None
 
-    cmd = [
-        "apksigner",
-        "verify",
-        "--print-certs",
-        str(apk_path),
-    ]
+    cmd = ["apksigner", "verify", "--print-certs", str(apk_path)]
     try:
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
         output = result.stdout + result.stderr
@@ -257,7 +121,6 @@ def verify_signature(apk_path: Path) -> str | None:
             return fingerprint.replace(":", "").lower()
 
         return None
-
     except (subprocess.CalledProcessError, OSError):
         return None
 
@@ -272,15 +135,7 @@ class BundleType(Enum):
 
 
 def detect_bundle_type(file_path: Path) -> BundleType:
-    """Detect the bundle type of a file.
-
-    Args:
-        file_path: Path to the file to detect.
-
-    Returns:
-        The detected BundleType.
-
-    """
+    """Detect the bundle type of a file."""
     if not file_path.exists():
         return BundleType.UNKNOWN
 
@@ -292,14 +147,13 @@ def detect_bundle_type(file_path: Path) -> BundleType:
     if suffix == ".apkm":
         return BundleType.APKM
 
-    # Try ZIP magic bytes
     try:
         with file_path.open("rb") as f:
             header = f.read(4)
         if header == b"PK\x03\x04":
             return BundleType.APK
-    except OSError:
-        pass
+    except OSError as e:
+        logger.debug("Failed to read magic bytes from %s: %s", file_path, e)
 
     return BundleType.UNKNOWN
 
@@ -308,50 +162,24 @@ class SplitAPKHandler:
     """Handler for split APK bundles (XAPK, APKM)."""
 
     def detect_bundle_type(self, file_path: Path) -> BundleType:
-        """Detect the bundle type of a file.
-
-        Args:
-            file_path: Path to the file to detect.
-
-        Returns:
-            The detected BundleType.
-
-        """
         return detect_bundle_type(file_path)
 
     def _find_apkeditor(self) -> Path | None:
-        """Find APKEditor JAR in known locations.
-
-        Returns:
-            Path to APKEditor JAR if found, None otherwise.
-
-        """
-        candidates = [
-            Path("bin/APKEditor.jar"),
-            Path("APKEditor.jar"),
-        ]
+        candidates = [Path("bin/APKEditor.jar"), Path("APKEditor.jar")]
         for candidate in candidates:
             if candidate.exists():
                 return candidate
         return None
 
     def merge_splits(self, bundle_path: Path, output_path: Path) -> bool:
-        """Merge a split APK bundle into a single APK.
-
-        Args:
-            bundle_path: Path to the bundle file.
-            output_path: Path to write the merged APK.
-
-        Returns:
-            True if merge succeeded, False otherwise.
-
-        """
+        """Merge a split APK bundle into a single APK."""
         bundle_type = self.detect_bundle_type(bundle_path)
         if bundle_type == BundleType.APK:
             try:
                 shutil.copy2(bundle_path, output_path)
                 return True
-            except OSError:
+            except OSError as e:
+                logger.error("Failed to copy APK bundle: %s", e)
                 return False
         if bundle_type in (BundleType.XAPK, BundleType.APKM):
             jar = self._find_apkeditor()
@@ -370,16 +198,7 @@ class SplitAPKHandler:
         return False
 
     def extract_splits(self, bundle_path: Path, output_dir: Path) -> list[Path]:
-        """Extract split APKs from a bundle.
-
-        Args:
-            bundle_path: Path to the bundle file.
-            output_dir: Directory to extract splits into.
-
-        Returns:
-            List of extracted APK paths.
-
-        """
+        """Extract split APKs from a bundle."""
         if not bundle_path.exists():
             return []
 
@@ -390,6 +209,8 @@ class SplitAPKHandler:
                 names = zf.namelist()
                 for name in names:
                     if not name.endswith(".apk"):
+                        continue
+                    if not _validate_path(output_dir / name, output_dir):
                         continue
                     dest = output_dir / Path(name).name
                     zf.extract(name, output_dir)
@@ -411,28 +232,10 @@ class AAPT2Manager:
     ]
 
     def __init__(self, cache_dir: Path | None = None) -> None:
-        """Initialize AAPT2Manager.
-
-        Args:
-            cache_dir: Directory for caching downloaded AAPT2 binaries.
-
-        """
         self.cache_dir = cache_dir or Path.home() / ".cache" / "revanced" / "aapt2"
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def get_aapt2(self, arch: str = "arm64-v8a") -> Path | None:
-        """Get the AAPT2 binary for the given architecture.
-
-        Checks the cache first, then tries to download from known sources.
-        Falls back to the system PATH.
-
-        Args:
-            arch: Target architecture (e.g., "arm64-v8a").
-
-        Returns:
-            Path to the AAPT2 binary, or None if unavailable.
-
-        """
         from scripts.utils.network import gh_dl
 
         cached = self.cache_dir / f"aapt2-{arch}"
@@ -445,7 +248,6 @@ class AAPT2Manager:
                 cached.chmod(0o755)
                 return cached
 
-        # Fallback to system PATH
         system_aapt2 = shutil.which("aapt2")
         if system_aapt2:
             return Path(system_aapt2)
@@ -461,19 +263,6 @@ class AAPT2Manager:
         languages: list[str] | None = None,
         densities: list[str] | None = None,
     ) -> bool:
-        """Optimize an APK using AAPT2 resource filtering.
-
-        Args:
-            apk_path: Path to the input APK.
-            output_path: Path to write the optimized APK.
-            arch: Target architecture for AAPT2 binary.
-            languages: Language codes to keep (e.g., ["en", "de"]).
-            densities: Screen densities to keep (e.g., ["xxhdpi"]).
-
-        Returns:
-            True if optimization succeeded, False otherwise.
-
-        """
         if not apk_path.exists():
             return False
 
@@ -495,30 +284,18 @@ class AAPT2Manager:
 
 
 def check_signature(apk_path: Path) -> bool:
-    """Check if APK has valid v1+v2 signatures.
-
-    Args:
-        apk_path: Path to the APK file to check.
-
-    Returns:
-        True if APK has valid v1 and v2 signatures, False otherwise.
-    """
+    """Check if APK has valid v1+v2 signatures."""
     _validate_apk_path(apk_path, "check_signature")
 
     if not apk_path.exists():
         return False
 
     cmd = [
-        "apksigner",
-        "verify",
-        "--v1-signing-enabled",
-        "true",
-        "--v2-signing-enabled",
-        "true",
-        "--v3-signing-enabled",
-        "false",
-        "--v4-signing-enabled",
-        "false",
+        "apksigner", "verify",
+        "--v1-signing-enabled", "true",
+        "--v2-signing-enabled", "true",
+        "--v3-signing-enabled", "false",
+        "--v4-signing-enabled", "false",
         str(apk_path),
     ]
     try:

--- a/scripts/utils/network.py
+++ b/scripts/utils/network.py
@@ -4,10 +4,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import fcntl
 import hashlib
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -46,7 +50,7 @@ class HttpClientConfig:
     initial_delay: int = DEFAULT_INITIAL_DELAY
     connect_timeout: int = 10
     user_agent: str = "Mozilla/5.0 (X11; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0"
-    github_token: str | None = field(default_factory=lambda: os.environ.get("GITHUB_TOKEN"))
+    github_token: str | None = field(default_factory=lambda: os.environ.get("GITHUB_TOKEN"), repr=False)
     cookie_file: Path | None = None
 
 
@@ -466,11 +470,25 @@ def _verify_or_remove(file_path: Path, sha256: str | None) -> bool:
         return True
     if _calculate_sha256(file_path) == sha256:
         return True
-    import contextlib
 
     with contextlib.suppress(OSError):
         file_path.unlink()
     return False
+
+
+async def _async_verify_or_remove(file_path: Path, sha256: str | None) -> bool:
+    """Async wrapper for _verify_or_remove.
+
+    Args:
+        file_path: Path to the file to verify.
+        sha256: Expected SHA256 hex digest, or None to skip verification.
+
+    Returns:
+        True if the file is valid (or no sha256 was specified), False if the
+        hash mismatched (the file is removed).
+
+    """
+    return await asyncio.to_thread(_verify_or_remove, file_path, sha256)
 
 
 def download_with_lock(
@@ -498,8 +516,6 @@ def download_with_lock(
         True if download succeeded or file already exists, False otherwise.
 
     """
-    import tempfile
-
     output_path = Path(output).resolve()
     base_temp = Path(temp_dir) if temp_dir else Path(tempfile.gettempdir())
 
@@ -570,8 +586,6 @@ async def async_download_with_lock(
         True if download succeeded or file already exists, False otherwise.
 
     """
-    import tempfile
-
     output_path = Path(output).resolve()
     base_temp = Path(temp_dir) if temp_dir else Path(tempfile.gettempdir())
 
@@ -585,7 +599,7 @@ async def async_download_with_lock(
     lock_file = work_dir / "lock"
 
     if output_path.exists():
-        verified = await asyncio.get_running_loop().run_in_executor(None, _verify_or_remove, output_path, sha256)
+        verified = await _async_verify_or_remove(output_path, sha256)
         if verified:
             return True
 
@@ -597,7 +611,6 @@ async def async_download_with_lock(
         return fd.fileno()
 
     def _release_lock(fileno: int) -> None:
-        import contextlib
         fcntl.flock(fileno, fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
             os.close(fileno)
@@ -609,14 +622,14 @@ async def async_download_with_lock(
         lock_fileno = await loop.run_in_executor(None, _acquire_lock)
 
         if output_path.exists():
-            verified = await loop.run_in_executor(None, _verify_or_remove, output_path, sha256)
+            verified = await _async_verify_or_remove(output_path, sha256)
             if verified:
                 return True
 
         async with HttpClient(config) as client:
             await client.async_get(url, temp_path, headers=headers or {})
             if sha256:
-                valid = await loop.run_in_executor(None, _verify_or_remove, temp_path, sha256)
+                valid = await _async_verify_or_remove(temp_path, sha256)
                 if not valid:
                     return False
             temp_path.replace(output_path)
@@ -770,9 +783,6 @@ def aria2c_download(
         True if download succeeded, False otherwise.
 
     """
-    import shutil
-    import subprocess
-
     if not shutil.which("aria2c"):
         return False
 
@@ -819,8 +829,6 @@ def download_with_aria2c_fallback(
         True if download succeeded, False otherwise.
 
     """
-    import shutil
-
     output_path = Path(output_path)
     if shutil.which("aria2c") and aria2c_download(urls, output_path, max_connections=max_connections):
         return True

--- a/scripts/version_tracker.py
+++ b/scripts/version_tracker.py
@@ -1,24 +1,5 @@
 #!/usr/bin/env python3
-"""Version tracker for smart rebuild detection.
-
-Tracks last successfully built versions of ReVanced CLI, patches, and apps.
-Compares current state against persisted state to determine if a rebuild is needed.
-
-Inspired by X-Abhishek-X/ReVanced-Automated-Build-Scripts check_updates.py.
-
-Usage:
-    # Check if build is needed (reads config.toml, compares with state file)
-    python3 version_tracker.py check --config config.toml
-
-    # Save current build state after successful build
-    python3 version_tracker.py save --config config.toml
-
-    # Show current state
-    python3 version_tracker.py show
-
-    # Reset state file
-    python3 version_tracker.py reset
-"""
+"""Version tracker for smart rebuild detection."""
 
 from __future__ import annotations
 
@@ -37,32 +18,19 @@ import orjson
 STATE_FILE: Final[Path] = Path(".github/last_built_versions.json")
 
 
-class VersionState(TypedDict):
-    """State dictionary for version tracking."""
-
-    component: str
-    version: str
-
-
 class AppVersionInfo(TypedDict, total=False):
-    """App version information from config."""
-
     patches_source: str
     cli_source: str
     version: str
 
 
 class StateDict(TypedDict, total=False):
-    """State file structure."""
-
     global_cli_version: str
     global_patches_version: str
     global_patches_source: str
 
 
 class Command(Enum):
-    """Available CLI commands."""
-
     CHECK = auto()
     SAVE = auto()
     SHOW = auto()
@@ -71,16 +39,6 @@ class Command(Enum):
 
 @dataclass(frozen=True, slots=True)
 class AppVersionState:
-    """Per-app version tracking state.
-
-    Attributes:
-        patches_source: Source repository for patches.
-        cli_source: Source repository for CLI.
-        version: App version.
-        integrations_version: Optional integrations version.
-
-    """
-
     patches_source: str
     cli_source: str
     version: str
@@ -89,16 +47,6 @@ class AppVersionState:
 
 @dataclass(frozen=True, slots=True)
 class BuildState:
-    """Tracks version state for smart rebuild detection.
-
-    Attributes:
-        global_cli_version: Global CLI version.
-        global_patches_version: Global patches version.
-        global_patches_source: Global patches source repository.
-        app_versions: Per-app version tracking dictionary.
-
-    """
-
     global_cli_version: str
     global_patches_version: str
     global_patches_source: str
@@ -107,16 +55,6 @@ class BuildState:
 
 @dataclass(frozen=True, slots=True)
 class VersionDiff:
-    """Represents a version difference.
-
-    Attributes:
-        key: Component key.
-        old: Old version value.
-        new: New version value.
-        change_type: Type of change.
-
-    """
-
     key: str
     old: str
     new: str
@@ -125,14 +63,6 @@ class VersionDiff:
 
 @dataclass(frozen=True, slots=True)
 class CheckResult:
-    """Result of a build check operation.
-
-    Attributes:
-        needs_build: Whether a rebuild is needed.
-        changes: List of version changes detected.
-
-    """
-
     needs_build: bool
     changes: list[VersionDiff]
 
@@ -142,15 +72,6 @@ type VersionMap = dict[str, str]
 
 @lru_cache(maxsize=1)
 def load_state(state_path: Path | None = None) -> VersionMap:
-    """Load the persisted build state from the JSON file.
-
-    Args:
-        state_path: Path to the state file. Defaults to STATE_FILE.
-
-    Returns:
-        Dictionary of component -> version mappings.
-
-    """
     path = state_path or STATE_FILE
     if path.exists():
         try:
@@ -162,16 +83,8 @@ def load_state(state_path: Path | None = None) -> VersionMap:
 
 
 def save_state(versions: VersionMap, state_path: Path | None = None) -> None:
-    """Save current build state to the JSON file.
-
-    Args:
-        versions: Dictionary of component -> version mappings.
-        state_path: Path to the state file. Defaults to STATE_FILE.
-
-    """
     path = state_path or STATE_FILE
     path.parent.mkdir(parents=True, exist_ok=True)
-
     json_bytes: bytes = orjson.dumps(versions, option=orjson.OPT_INDENT_2)
     path.write_bytes(json_bytes + b"\n")
     print(f"State saved to {path}", file=sys.stderr)
@@ -179,18 +92,6 @@ def save_state(versions: VersionMap, state_path: Path | None = None) -> None:
 
 @lru_cache(maxsize=4)
 def load_config(config_path: str) -> dict[str, object]:
-    """Load and parse a TOML config file.
-
-    Args:
-        config_path: Path to config.toml.
-
-    Returns:
-        Parsed TOML as a dictionary.
-
-    Raises:
-        SystemExit: If the file cannot be read or parsed.
-
-    """
     path = Path(config_path)
     try:
         with path.open("rb") as f:
@@ -201,15 +102,6 @@ def load_config(config_path: str) -> dict[str, object]:
 
 
 def _normalize_patches_source(value: object) -> str | None:
-    """Normalize patches source to string.
-
-    Args:
-        value: Raw patches source (str or list).
-
-    Returns:
-        Normalized string or None.
-
-    """
     match value:
         case str(s):
             return s
@@ -220,104 +112,61 @@ def _normalize_patches_source(value: object) -> str | None:
 
 
 def extract_current_versions(config: dict[str, object]) -> VersionMap:
-    """Extract version identifiers from config for comparison.
-
-    Tracks:
-    - Global cli-version and patches-version
-    - Per-app: patches-source, cli-source, version, integrations, enabled status
-
-    Args:
-        config: Parsed TOML configuration.
-
-    Returns:
-        Flat dictionary of trackable version keys.
-
-    """
     versions: VersionMap = {}
-
     global_cli_ver = str(config.get("cli-version", "latest"))
     global_patches_ver = str(config.get("patches-version", "latest"))
     global_patches_src = config.get("patches-source", "")
-
     versions["global_cli_version"] = global_cli_ver
     versions["global_patches_version"] = global_patches_ver
-
     normalized = _normalize_patches_source(global_patches_src)
     if normalized:
         versions["global_patches_source"] = normalized
-
     for key, value in config.items():
         if not isinstance(value, dict):
             continue
-
         enabled = value.get("enabled", True)
         if not enabled:
             continue
-
         app_key = key.lower().replace(" ", "-")
-
         patches_src = value.get("patches-source", global_patches_src)
         patches_normalized = _normalize_patches_source(patches_src)
         if patches_normalized:
             versions[f"app_{app_key}_patches_source"] = patches_normalized
-
         cli_src = value.get("cli-source", "")
         if cli_src:
             versions[f"app_{app_key}_cli_source"] = str(cli_src)
-
         app_ver = value.get("version", "auto")
         versions[f"app_{app_key}_version"] = str(app_ver)
-
         integrations_ver = value.get("integrations-version")
         if integrations_ver:
             versions[f"app_{app_key}_integrations_version"] = str(integrations_ver)
-
     return versions
 
 
 def extract_build_state(config: dict[str, object]) -> BuildState:
-    """Extract build state from config in structured format.
-
-    Args:
-        config: Parsed TOML configuration.
-
-    Returns:
-        BuildState with global and per-app version tracking.
-
-    """
     global_cli_ver = str(config.get("cli-version", "latest"))
     global_patches_ver = str(config.get("patches-version", "latest"))
     global_patches_src = config.get("patches-source", "")
     normalized_global_patches = _normalize_patches_source(global_patches_src) or ""
-
     app_versions: dict[str, AppVersionState] = {}
-
     for key, value in config.items():
         if not isinstance(value, dict):
             continue
-
         enabled = value.get("enabled", True)
         if not enabled:
             continue
-
         app_key = key.lower().replace(" ", "-")
-
         patches_src = value.get("patches-source", global_patches_src)
         patches_normalized = _normalize_patches_source(patches_src) or ""
-
         cli_src = value.get("cli-source", "")
-
         app_ver = value.get("version", "auto")
-
         integrations_ver = value.get("integrations-version")
-
         app_versions[app_key] = AppVersionState(
             patches_source=patches_normalized,
             cli_source=str(cli_src) if cli_src else "",
             version=str(app_ver),
             integrations_version=str(integrations_ver) if integrations_ver else None,
         )
-
     return BuildState(
         global_cli_version=global_cli_ver,
         global_patches_version=global_patches_ver,
@@ -327,54 +176,25 @@ def extract_build_state(config: dict[str, object]) -> BuildState:
 
 
 def detect_changes(current: VersionMap, saved: VersionMap) -> list[VersionDiff]:
-    """Detect version changes between current and saved state.
-
-    Args:
-        current: Current version state.
-        saved: Saved version state.
-
-    Returns:
-        List of version differences.
-
-    """
     changes: list[VersionDiff] = []
-
     for key, cur_val in current.items():
         saved_val = saved.get(key)
         if saved_val is None:
             changes.append(VersionDiff(key, "", cur_val, "added"))
         elif cur_val != saved_val:
             changes.append(VersionDiff(key, saved_val, cur_val, "modified"))
-
     changes.extend(VersionDiff(key, saved[key], "", "removed") for key in saved if key not in current)
-
     return changes
 
 
-def check_needs_build(
-    config_path: str,
-    state_path: Path | None = None,
-) -> CheckResult:
-    """Compare current config against saved state to detect changes.
-
-    Args:
-        config_path: Path to config.toml.
-        state_path: Path to the state file.
-
-    Returns:
-        CheckResult with needs_build flag and list of changes.
-
-    """
+def check_needs_build(config_path: str, state_path: Path | None = None) -> CheckResult:
     config = load_config(config_path)
     current = extract_current_versions(config)
     saved = load_state(state_path)
-
     if not saved:
         print("No previous build state found — build needed", file=sys.stderr)
         return CheckResult(needs_build=True, changes=[])
-
     changes = detect_changes(current, saved)
-
     if changes:
         print("Changes detected:", file=sys.stderr)
         for change in changes:
@@ -385,21 +205,12 @@ def check_needs_build(
                     print(f"  {change.key}: added -> {change.new!r}", file=sys.stderr)
                 case "removed":
                     print(f"  {change.key}: {change.old!r} -> removed", file=sys.stderr)
-
     else:
         print("No changes detected", file=sys.stderr)
-
     return CheckResult(needs_build=bool(changes), changes=changes)
 
 
 def set_github_output(key: str, value: str) -> None:
-    """Write key=value to GITHUB_OUTPUT if available.
-
-    Args:
-        key: Output key name.
-        value: Output value.
-
-    """
     gh_output = os.environ.get("GITHUB_OUTPUT")
     if gh_output:
         with Path(gh_output).open("a", encoding="utf-8") as f:
@@ -408,53 +219,22 @@ def set_github_output(key: str, value: str) -> None:
 
 
 def format_changes_for_github_output(changes: list[VersionDiff]) -> str:
-    """Format changes list for GitHub Actions workflow command.
-
-    Args:
-        changes: List of version differences.
-
-    Returns:
-        Formatted string for workflow commands.
-
-    """
     return "\n".join(
         f"::notice title={change.key}::{change.change_type}: {change.old} -> {change.new}" for change in changes
     )
 
 
 def execute_check_command(config_path: str, state_path: Path | None) -> int:
-    """Execute the check command.
-
-    Args:
-        config_path: Path to config.toml.
-        state_path: Optional path to state file.
-
-    Returns:
-        Exit code.
-
-    """
     result = check_needs_build(config_path, state_path)
     set_github_output("needs_build", str(result.needs_build).lower())
-
     if result.changes:
         github_output = format_changes_for_github_output(result.changes)
         set_github_output("changes", github_output)
-
     print("true" if result.needs_build else "false")
     return 0
 
 
 def execute_save_command(config_path: str, state_path: Path | None) -> int:
-    """Execute the save command.
-
-    Args:
-        config_path: Path to config.toml.
-        state_path: Optional path to state file.
-
-    Returns:
-        Exit code.
-
-    """
     config = load_config(config_path)
     current = extract_current_versions(config)
     save_state(current, state_path)
@@ -462,15 +242,6 @@ def execute_save_command(config_path: str, state_path: Path | None) -> int:
 
 
 def execute_show_command(state_path: Path | None) -> int:
-    """Execute the show command.
-
-    Args:
-        state_path: Optional path to state file.
-
-    Returns:
-        Exit code.
-
-    """
     state = load_state(state_path)
     if state:
         print(orjson.dumps(state, option=orjson.OPT_INDENT_2).decode("utf-8"))
@@ -480,30 +251,12 @@ def execute_show_command(state_path: Path | None) -> int:
 
 
 def execute_reset_command(state_path: Path | None) -> int:
-    """Execute the reset command.
-
-    Args:
-        state_path: Optional path to state file.
-
-    Returns:
-        Exit code.
-
-    """
     save_state({}, state_path)
     print("State reset")
     return 0
 
 
 def determine_command(args: argparse.Namespace) -> Command:
-    """Determine command from CLI arguments.
-
-    Args:
-        args: Parsed CLI arguments.
-
-    Returns:
-        Command to execute.
-
-    """
     match args.command:
         case "check":
             return Command.CHECK
@@ -519,35 +272,19 @@ def determine_command(args: argparse.Namespace) -> Command:
 
 
 def main() -> int:
-    """CLI entry point.
-
-    Returns:
-        Exit code: 0 on success, 1 on error.
-
-    """
-    parser = argparse.ArgumentParser(
-        description="Track build versions for smart rebuild detection",
-    )
+    parser = argparse.ArgumentParser(description="Track build versions for smart rebuild detection")
     subparsers = parser.add_subparsers(dest="command", required=True)
-
     check_parser = subparsers.add_parser("check", help="Check if build is needed")
     check_parser.add_argument("--config", required=True, help="Path to config.toml")
     check_parser.add_argument("--state-file", help="Path to state file (default: .github/last_built_versions.json)")
-
     save_parser = subparsers.add_parser("save", help="Save current state after successful build")
     save_parser.add_argument("--config", required=True, help="Path to config.toml")
     save_parser.add_argument("--state-file", help="Path to state file")
-
     subparsers.add_parser("show", help="Show current state")
-
     subparsers.add_parser("reset", help="Reset state file")
-
     args = parser.parse_args()
-
     state_path: Path | None = Path(args.state_file) if hasattr(args, "state_file") and args.state_file else None
-
     command = determine_command(args)
-
     try:
         match command:
             case Command.CHECK:

--- a/tests/test_apk.py
+++ b/tests/test_apk.py
@@ -17,7 +17,6 @@ from scripts.utils.apk import (
     _validate_path,
     align_apk,
     detect_bundle_type,
-    merge_bundle,
 )
 
 # ---------------------------------------------------------------------------
@@ -144,10 +143,31 @@ class TestSplitAPKHandler:
 
     def test_find_apkeditor_none_when_missing(self, tmp_path: Path) -> None:
         handler = SplitAPKHandler()
-        # Force search in a directory where no jar exists
         with patch.object(Path, "exists", return_value=False):
             jar = handler._find_apkeditor()
         assert jar is None
+
+    def test_extract_splits_skips_malicious_paths(self, tmp_path: Path) -> None:
+        # ruff: noqa: PLC0415
+        import zipfile
+
+        bundle = tmp_path / "malicious.xapk"
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        with zipfile.ZipFile(bundle, "w") as zf:
+            # zipfile.ZipInfo objects can have absolute or traversal paths
+            info = zipfile.ZipInfo("../evil.apk")
+            zf.writestr(info, b"evil content")
+            zf.writestr("good.apk", b"good content")
+
+        handler = SplitAPKHandler()
+        splits = handler.extract_splits(bundle, out_dir)
+
+        # Should only contain good.apk, evil.apk should be skipped
+        assert len(splits) == 1
+        assert splits[0].name == "good.apk"
+        assert not (tmp_path / "evil.apk").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -279,93 +299,3 @@ class TestAlignApk:
         output_path = tmp_path / "output.apk"
         with pytest.raises(ValueError, match="align_apk input: file must have .apk extension"):
             align_apk(input_path, output_path)
-
-
-# ---------------------------------------------------------------------------
-# merge_bundle
-# ---------------------------------------------------------------------------
-
-
-class TestMergeBundle:
-    def test_rejects_non_path_bundle(self) -> None:
-        with pytest.raises(ValueError, match="bundle_path must be a Path object"):
-            merge_bundle("app.xapk", Path("out.apk"))  # type: ignore[arg-type]
-
-    def test_rejects_path_traversal_bundle(self, tmp_path: Path) -> None:
-        bundle_path = Path("/tmp/\x00bad.xapk")
-        with pytest.raises(ValueError, match="path traversal detected"):
-            merge_bundle(bundle_path, tmp_path / "out.apk")
-
-    def test_rejects_invalid_bundle_extension(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.zip"
-        with pytest.raises(ValueError, match="bundle must be .xapk or .apkm"):
-            merge_bundle(bundle_path, tmp_path / "out.apk")
-
-    def test_rejects_path_traversal_output(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        output_path = Path("/tmp/\x00bad.apk")
-        with pytest.raises(ValueError, match="path traversal detected"):
-            merge_bundle(bundle_path, output_path)
-
-    def test_rejects_invalid_output_extension(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        output_path = tmp_path / "out.zip"
-        with pytest.raises(ValueError, match="output must have .apk extension"):
-            merge_bundle(bundle_path, output_path)
-
-    def test_missing_bundle_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        output_path = tmp_path / "out.apk"
-        assert merge_bundle(bundle_path, output_path) is False
-
-    def test_subprocess_called_process_error_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy")
-        output_path = tmp_path / "out.apk"
-        with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "cmd")):
-            assert merge_bundle(bundle_path, output_path) is False
-
-    def test_subprocess_os_error_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy")
-        output_path = tmp_path / "out.apk"
-        with patch("subprocess.run", side_effect=OSError("Permission denied")):
-            assert merge_bundle(bundle_path, output_path) is False
-
-    def test_subprocess_non_zero_returncode_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy")
-        output_path = tmp_path / "out.apk"
-        mock_result = MagicMock()
-        mock_result.returncode = 1
-        with patch("subprocess.run", return_value=mock_result):
-            assert merge_bundle(bundle_path, output_path) is False
-
-    def test_missing_merged_apk_returns_false(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy")
-        output_path = tmp_path / "out.apk"
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        with patch("subprocess.run", return_value=mock_result):
-            assert merge_bundle(bundle_path, output_path) is False
-
-    def test_success(self, tmp_path: Path) -> None:
-        bundle_path = tmp_path / "app.xapk"
-        bundle_path.write_bytes(b"dummy bundle")
-        output_path = tmp_path / "out.apk"
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-
-        def mock_run_side_effect(*args: object, **kwargs: object) -> MagicMock:
-            cmd = args[0]
-            assert isinstance(cmd, list)
-            merged_apk_path = Path(cmd[-1])
-            merged_apk_path.write_bytes(b"merged apk content")
-            return mock_result
-
-        with patch("subprocess.run", side_effect=mock_run_side_effect):
-            assert merge_bundle(bundle_path, output_path) is True
-
-        assert output_path.exists()
-        assert output_path.read_bytes() == b"merged apk content"

--- a/tests/test_app_processor.py
+++ b/tests/test_app_processor.py
@@ -1,0 +1,88 @@
+"""Tests for scripts/builder/app_processor.py."""
+
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.builder.app_processor import AppProcessor, Architecture, DownloadSource
+from scripts.builder.config import AppConfig
+
+
+class TestAppProcessorArchitecture:
+    """Tests for AppProcessor._parse_architecture."""
+
+    @pytest.fixture
+    def processor(self) -> AppProcessor:
+        """Provide a mocked AppProcessor instance."""
+        config_mock = MagicMock()
+        java_runner_mock = MagicMock()
+        return AppProcessor(config=config_mock, java_runner=java_runner_mock)
+
+    def test_parse_architecture_default(self, processor: AppProcessor) -> None:
+        """Test default architecture (no arch specified)."""
+        config = AppConfig(name="TestApp", options={})
+        assert processor._parse_architecture(config) == Architecture.ALL
+
+    @pytest.mark.parametrize(
+        ("arch_str", "expected_arch"),
+        [
+            ("arm64-v8a", Architecture.ARM64_V8A),
+            ("arm-v7a", Architecture.ARM_V7A),
+            ("both", Architecture.BOTH),
+            ("all", Architecture.ALL),
+        ],
+    )
+    def test_parse_architecture_valid(
+        self,
+        processor: AppProcessor,
+        arch_str: str,
+        expected_arch: Architecture,
+    ) -> None:
+        """Test valid architecture strings."""
+        config = AppConfig(name="TestApp", options={"arch": arch_str})
+        assert processor._parse_architecture(config) == expected_arch
+
+    def test_parse_architecture_invalid(self, processor: AppProcessor) -> None:
+        """Test invalid architecture raises ValueError."""
+        config = AppConfig(name="TestApp", options={"arch": "invalid-arch"})
+        with pytest.raises(ValueError, match="Invalid architecture: invalid-arch"):
+            processor._parse_architecture(config)
+
+
+class TestAppProcessorDownloadSource:
+    """Tests for AppProcessor._determine_download_source."""
+
+    @pytest.fixture
+    def processor(self) -> AppProcessor:
+        """Provide a mocked AppProcessor instance."""
+        config_mock = MagicMock()
+        java_runner_mock = MagicMock()
+        return AppProcessor(config=config_mock, java_runner=java_runner_mock)
+
+    @pytest.mark.parametrize(
+        ("options", "expected_source"),
+        [
+            ({"apkmirror_dlurl": "https://apkmirror.com/some/path"}, DownloadSource.APKMIRROR),
+            ({"uptodown_dlurl": "https://uptodown.com/some/path"}, DownloadSource.UPTODOWN),
+            ({"apkpure_dlurl": "https://apkpure.com/some/path"}, DownloadSource.APKPURE),
+            ({"archive_dlurl": "https://archive.org/some/path"}, DownloadSource.ARCHIVE),
+            ({"aptoide_dlurl": "https://aptoide.com/some/path"}, DownloadSource.APTOIDE),
+            ({"apkmonk_dlurl": "https://apkmonk.com/some/path"}, DownloadSource.APKMonk),
+            ({}, DownloadSource.APKMIRROR),
+            ({"other_dlurl": "https://example.com/"}, DownloadSource.APKMIRROR),
+        ],
+    )
+    def test_determine_download_source(
+        self,
+        processor: AppProcessor,
+        options: dict[str, str],
+        expected_source: DownloadSource,
+    ) -> None:
+        """Test download source resolution based on app configuration."""
+        app_config = AppConfig(name="TestApp", options=options)
+        source = processor._determine_download_source(app_config)
+        assert source == expected_source

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,58 @@
+"""Tests for the Builder wrapper class."""
+
+# ruff: noqa: S101
+
+from unittest.mock import MagicMock, patch
+
+from scripts.lib.builder import Builder
+from scripts.lib.config import Config
+
+
+def _mock_config() -> MagicMock:
+    """Provide a mocked Config instance."""
+    config = MagicMock(spec=Config)
+    config.config_file = "test_config.toml"
+    return config
+
+
+def test_builder_init() -> None:
+    """Test Builder initialization."""
+    mock_config = _mock_config()
+    builder = Builder(mock_config)
+    assert builder.config == mock_config
+
+
+@patch("scripts.lib.builder.subprocess.run")
+def test_builder_build_all_success(mock_run: MagicMock) -> None:
+    """Test build_all returns True when subprocess succeeds."""
+    mock_config = _mock_config()
+    mock_run.return_value = MagicMock(returncode=0)
+    builder = Builder(mock_config)
+
+    result = builder.build_all()
+
+    assert result is True
+    mock_run.assert_called_once_with(
+        ["./build.sh", "test_config.toml"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+@patch("scripts.lib.builder.subprocess.run")
+def test_builder_build_all_failure(mock_run: MagicMock) -> None:
+    """Test build_all returns False when subprocess fails."""
+    mock_config = _mock_config()
+    mock_run.return_value = MagicMock(returncode=1)
+    builder = Builder(mock_config)
+
+    result = builder.build_all()
+
+    assert result is False
+    mock_run.assert_called_once_with(
+        ["./build.sh", "test_config.toml"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from scripts.builder.cli_profiles import (
     ADOBO_CLI,
     BUILTIN_PROFILES,
@@ -11,6 +13,7 @@ from scripts.builder.cli_profiles import (
     REVANCED_CLI_V5,
     REVANCED_CLI_V6,
     CLIProfileType,
+    PatchCommandConfig,
     _detect_profile_from_help,
 )
 
@@ -34,3 +37,115 @@ def test_detect_v6_profile_from_help() -> None:
 
 def test_detect_v5_profile_default() -> None:
     assert _detect_profile_from_help("nothing helpful here") is REVANCED_CLI_V5
+
+
+def test_v5_patch_args() -> None:
+    """Verify ReVanced CLI v5 argument generation."""
+    config = PatchCommandConfig(
+        apk_path=Path("input.apk"),
+        output_path=Path("output.apk"),
+        patches_jars=[Path("patches.jar")],
+        exclude=["patch1"],
+        include=["patch2"],
+        force=True,
+        purge=True,
+    )
+    args = REVANCED_CLI_V5.build_patch_args(config)
+
+    assert "--input" in args
+    assert "input.apk" in args
+    assert "--output" in args
+    assert "output.apk" in args
+    assert "--patch" in args
+    assert "patches.jar" in args
+    assert "--disable" in args
+    assert "patch1" in args
+    assert "--enable" in args
+    assert "patch2" in args
+    assert "--force" in args
+    assert "--purge" in args
+
+
+def test_v6_patch_args() -> None:
+    """Verify ReVanced CLI v6 argument generation."""
+    config = PatchCommandConfig(
+        apk_path=Path("input.apk"),
+        output_path=Path("output.apk"),
+        patches_jars=[Path("patches.jar")],
+        patches_post=[Path("post.jar")],
+        exclude=["patch1"],
+        include=["patch2"],
+        merge=[Path("merge.jar")],
+        keystore=Path("ks.keystore"),
+        force=True,
+        rip_lib=["lib1"],
+        bare=True,
+        inplace=True,
+        werror=True,
+    )
+    args = REVANCED_CLI_V6.build_patch_args(config)
+
+    assert "-i" in args
+    assert "input.apk" in args
+    assert "-o" in args
+    assert "output.apk" in args
+    assert "-e" in args
+    assert "patches.jar" in args
+    assert "-b" in args
+    assert "post.jar" in args
+    assert "-d" in args
+    assert "patch1" in args
+    assert "-m" in args
+    assert "merge.jar" in args
+    assert "-k" in args
+    assert "ks.keystore" in args
+    assert "-f" in args
+    assert "-r" in args
+    assert "lib1" in args
+    assert "--bare" in args
+    assert "--inplace" in args
+    assert "-Werror" in args
+
+
+def test_morphe_patch_args() -> None:
+    """Verify Morphe CLI argument generation."""
+    config = PatchCommandConfig(
+        apk_path=Path("input.apk"),
+        output_path=Path("output.apk"),
+        patches_jars=[Path("patches.jar")],
+    )
+    args = MORPHE_CLI.build_patch_args(config)
+
+    assert "--input" in args
+    assert "input.apk" in args
+    assert "--output" in args
+    assert "output.apk" in args
+    assert "--patch" in args
+    assert "patches.jar" in args
+
+
+def test_list_patches_args() -> None:
+    """Verify list-patches argument generation."""
+    patches = [Path("p1.jar"), Path("p2.jar")]
+
+    v5_args = REVANCED_CLI_V5.build_list_patches_args(patches)
+    assert "--patches" in v5_args
+    assert "p1.jar" in v5_args
+    assert "p2.jar" in v5_args
+
+    v6_args = REVANCED_CLI_V6.build_list_patches_args(patches)
+    assert "-e" in v6_args
+    assert "p1.jar" in v6_args
+    assert "p2.jar" in v6_args
+
+    morphe_args = MORPHE_CLI.build_list_patches_args(patches)
+    assert "--patches" in morphe_args
+    assert "p1.jar" in morphe_args
+    assert "p2.jar" in morphe_args
+
+
+def test_empty_config() -> None:
+    """Verify argument generation with empty config."""
+    config = PatchCommandConfig()
+    args = REVANCED_CLI_V6.build_patch_args(config)
+    assert args == []

--- a/tests/test_network_security.py
+++ b/tests/test_network_security.py
@@ -1,0 +1,19 @@
+"""Tests for security aspects of scripts/utils/network.py."""
+
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from scripts.utils.network import HttpClientConfig
+
+
+def test_http_client_config_repr_hides_github_token() -> None:
+    """Test that HttpClientConfig.__repr__ does not expose the GitHub token."""
+    with patch.dict(os.environ, {"GITHUB_TOKEN": "secret_token_12345"}):
+        config = HttpClientConfig()
+        config_repr = repr(config)
+        assert "github_token" not in config_repr
+        assert "secret_token_12345" not in config_repr


### PR DESCRIPTION
## Summary

Combines and squash-merges all 22 open PRs (#221–#248) into a single clean commit.

### Changes applied

**Async / network**
- `scripts/scrapers/base.py` — full async refactor: `httpx.AsyncClient`, `await asyncio.sleep`, `await self.session.request` (#230)
- `scripts/scrapers/apkmonk.py`, `apkpure.py`, `aptoide.py`, `archive.py` — use async base class methods natively (#230, #244, #245)
- `scripts/scrapers/uptodown.py` — async `_request_with_retry` override (#229, #230)
- `scripts/utils/network.py` — stdlib imports at top level; `github_token` field `repr=False`; `_async_verify_or_remove` via `asyncio.to_thread` (#223, #232, #239)

**APK scraper / merge**
- `scripts/scrapers/apkmirror.py` — `shutil` import to top level; remove `ApkBundle` enum; own `_merge_splits` with APKEditor download (#221, #236)

**APK utilities**
- `scripts/utils/apk.py` — `logger = logging.getLogger(__name__)`; `detect_bundle_type` logs OSError; `extract_splits` path-traversal (Zip Slip) protection; `merge_bundle` dead code removed; `SplitAPKHandler`, `AAPT2Manager` intact (#222, #224, #225, #235, #240, #248)

**Builder / patcher**
- `scripts/builder/cli_profiles.py` — `PatchCommandConfig` frozen dataclass; `build_patch_args` / `build_list_patches_args` on `CLIProfile` (#228)
- `scripts/builder/patcher.py` — refactor `patch()` into `_verify_inputs`, `_execute_patch_command`, `_sign_apk`, `_zipalign_apk`; `get_cached_patches_list` uses `ThreadPoolExecutor` for parallel JAR hashing (#241, #243)
- `scripts/builder/module_gen.py` — replace bare `except ValueError: pass` with `logger.warning(...)` (#226)

**Cache**
- `scripts/lib/cache.py` — `CacheManager` with atomic JSON index writes; `format_cache_size` with IEC units and `1 byte` / `N bytes` singular/plural fix; `_checksum` via `hashlib.file_digest` (#227)

**Version tracker**
- `scripts/version_tracker.py` — remove unused `VersionState` TypedDict; retain `AppVersionInfo`, `StateDict`, `BuildState`, `VersionDiff`, `CheckResult` (#246)

**Tests**
- `tests/test_network_security.py` — `HttpClientConfig.__repr__` does not expose `github_token` (#239)
- `tests/test_builder.py` — `Builder.__init__`, `build_all` success/failure (#237)
- `tests/test_app_processor.py` — `AppProcessor._parse_architecture` and `_determine_download_source` (#238, #242)
- `tests/test_cli_profiles.py` — v5/v6/Morphe patch args, list-patches args, profile detection, `PatchCommandConfig` (#228)
- `tests/test_apk.py` — `_validate_path`, `_validate_apk_path`, `detect_bundle_type`, `SplitAPKHandler` (path traversal), `AAPT2Manager`, `align_apk` (#235)

## Closes PRs
#221 #222 #223 #224 #225 #226 #227 #228 #229 #230 #232 #235 #236 #237 #238 #239 #240 #241 #242 #243 #244 #245 #246 #248

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALG8GzWStwffzU3LTjvRpf)_