### PR TITLE
feat(builder): support dynamic artifact name derivation for CLI and patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ uv run python -m pytest tests -v
 
 ## Configuration
 
-The shipped `config.toml` uses top-level global settings plus per-app sections such as `[YouTube-Extended]`. Each enabled app needs at least one download source:
+The shipped `config.toml` uses top-level global settings plus per-app sections such as `[YouTube-Extended]` or `[YouTube-Morphed]`. Each enabled app needs at least one download source:
 
 - `apkmirror-dlurl`
 - `uptodown-dlurl`
@@ -93,15 +93,16 @@ Common global settings include:
 - `build-mode`
 - `patches-version`
 - `cli-version`
-- `patches-source`
-- `cli-source`
+- `patches-source` (defaults to `MorpheApp/morphe-patches`)
+- `cli-source` (defaults to `MorpheApp/morphe-cli`)
+- `cli-profile` (defaults to `"auto"`; detects `revanced-cli-v5`, `revanced-cli-v6`, `morphe-cli`, or `adobo-cli` from `--help`)
 - `arch`
 - `riplib`
 - `enable-aapt2-optimize`
 - `aapt2-source`
 - `use-custom-aapt2`
 
-The sample config currently enables `Music-Extended` and `YouTube-Extended`; other app sections are included as examples and are disabled by default.
+The sample config enables `Music-Morphed` and `YouTube-Morphed` (Morphe default). Other sections (`Music-Extended`, `YouTube-Extended`, `X`, `Spotify`, etc.) are included as examples and are disabled by default — flip `enabled = true` to use them.
 
 ### Patch sources
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -20,22 +20,29 @@ default values if not set explicitly.
 parallel-jobs = 1                    # amount of cores to use for parallel patching, if not set $(nproc) is used
 compression-level = 9                # module zip compression level
 remove-rv-integrations-checks = true # remove checks from the revanced integrations
-# Multiple patch sources can be specified as an array (patches are merged, later sources override earlier ones on conflicts)
+# Multiple patch sources can be specified as an array (patches are merged, later sources override earlier ones on conflicts).
+# The default is Morphe (MorpheApp/morphe-patches + MorpheApp/morphe-cli).
 patches-source = [
-  "MorpheApp/morphe-patches",       # default
-  "jkennethcarino/adobo",           # Morphe-compatible add-on patches
+  "MorpheApp/morphe-patches",       # default Morphe patches
+  "jkennethcarino/adobo",           # Morphe-compatible add-on patches (run on Morphe CLI)
   # "brosssh/revanced-external-bundles",         # resolves via the external-bundles aggregator (matched by package id)
   # "external-bundles:revanced-patches"          # explicit bundle_type selector
 ]
 # Single source still works for backwards compatibility:
 # patches-source = "MorpheApp/morphe-patches"
-cli-source = "j-hc/revanced-cli"             # where to fetch cli from. default: "ReVanced/revanced-cli"
-# Supported CLI flavors (auto-detected from --help): ReVanced CLI v5/v6, Morphe CLI, Adobo CLI.
-# Force a specific profile with cli-profile (default "auto"): "revanced-cli-v5", "revanced-cli-v6", "morphe-cli", "adobo-cli".
+cli-source = "MorpheApp/morphe-cli"             # where to fetch CLI from. default: "MorpheApp/morphe-cli"
+# Supported CLI flavors (auto-detected from `java -jar <cli> --help`):
+#   - "revanced-cli-v5"   ReVanced CLI v5 (long flags, `--patch`, `--input`)
+#   - "revanced-cli-v6"   ReVanced CLI v6 (short flags, `-e`, `-i`)
+#   - "morphe-cli"        Morphe CLI (long flags, `--patch`, `--input`)
+#   - "adobo-cli"         Adobo CLI (Morphe-compatible flag set)
+# Force a specific profile with cli-profile (default "auto"). Auto-detection
+# inspects `--help` and falls back to ReVanced CLI v5 on uncertainty.
+cli-profile = "auto"
 # options like cli-source can also set per app
-rv-brand = "ReVanced Extended" # rebrand from 'ReVanced' to something different. default: "ReVanced"
-patches-version = "v2.160.0" # 'latest', 'dev', or a version number. default: "latest"
-cli-version = "v5.0.0"       # 'latest', 'dev', or a version number. default: "latest"
+rv-brand = "Morphe" # rebrand from 'Morphe' to something different. default: "Morphe"
+patches-version = "latest" # 'latest', 'dev', or a version number. default: "latest"
+cli-version = "latest"     # 'latest', 'dev', or a version number. default: "latest"
 [Some-App]
 app-name = "SomeApp" # if set, release name becomes SomeApp instead of Some-App. default is same as table name, which is 'Some-App' here.
 enabled = true       # whether to build the app. default: true
@@ -62,5 +69,16 @@ uptodown-dlurl = "https://spotify.en.uptodown.com/android"
 module-prop-name = "some-app-magisk"                       # magisk module prop name.
 apkmirror-dpi = "360-480dpi"                               # used to select apk variant from apkmirror. default: nodpi
 arch = "arm64-v8a"                                         # 'arm64-v8a', 'arm-v7a', 'all', 'both'. 'both' downloads both arm64-v8a and arm-v7a. default: all
-riplib = true                                              # enables ripping x86 and x86_64 libs from apks with j-hc revanced cli. default: true
+riplib = true                                              # enables stripping the other ABI's .so files from APKs. default: true
+
+# ============================================================================
+# Patch sources reference
+# ============================================================================
+# Morphe (default):      MorpheApp/morphe-patches     + MorpheApp/morphe-cli
+# ReVanced:              ReVanced/revanced-patches    + ReVanced/revanced-cli
+# ReVanced Extended:     anddea/revanced-patches      + inotia00/revanced-cli
+# Adobo (Morphe-compat): jkennethcarino/adobo        + MorpheApp/morphe-cli
+# Piko (Twitter/X):      crimera/piko                 + (ReVanced/Morphe CLI)
+# Patcheddit (Reddit):   wchill/patcheddit            + (ReVanced/Morphe CLI)
+# External bundles:      brosssh/revanced-external-bundles (or `external-bundles:<bundle_type>`)
 ```

--- a/docs/generator.html
+++ b/docs/generator.html
@@ -104,12 +104,12 @@
                     <div class="form-group">
                         <label for="patches-source">Default Patches Source</label>
                         <input type="text" id="patches-source" value="MorpheApp/morphe-patches">
-                        <p class="help-text">GitHub repo (owner/name) for patches. Also accepts `brosssh/revanced-external-bundles` or `external-bundles:&lt;type&gt;`.</p>
+                        <p class="help-text">GitHub repo (owner/name) for patches. Accepts `MorpheApp/morphe-patches`, `ReVanced/revanced-patches`, `jkennethcarino/adobo`, `brosssh/revanced-external-bundles`, or `external-bundles:&lt;type&gt;`.</p>
                     </div>
                     <div class="form-group">
                         <label for="cli-source">Default CLI Source</label>
                         <input type="text" id="cli-source" value="MorpheApp/morphe-cli">
-                        <p class="help-text">GitHub repo for the patcher CLI (Morphe / ReVanced).</p>
+                        <p class="help-text">GitHub repo for the patcher CLI. Use `MorpheApp/morphe-cli`, `ReVanced/revanced-cli`, `j-hc/revanced-cli`, or `inotia00/revanced-cli`. CLI flavor is auto-detected from <code>--help</code>; force a profile with <code>cli-profile</code> in TOML if needed.</p>
                     </div>
                     <div class="form-group">
                         <label for="patches-version">Patches Version</label>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
                     <span class="hero-title-accent">ReVanced</span> Builder
                 </h1>
                 <p class="hero-subtitle">
-                    Automated APK patching system for ReVanced and RVX.
+                    Automated APK patching for Morphe, ReVanced, RVX, Piko, Patcheddit, Adobo and the brosssh external-bundles aggregator.
                     Download stock APKs, apply patches, and build optimized APKs &mdash; all from a single config file.
                 </p>
                 <div class="hero-actions">
@@ -74,7 +74,7 @@
                         <span class="feature-card-icon" aria-hidden="true">&#x1f4e6;</span>
                         <h3 class="feature-card-title">Multi-Source Patches</h3>
                         <p class="feature-card-desc">
-                            Combine patches from multiple GitHub repositories. Version detection uses union strategy &mdash; the highest version supported by at least one source.
+                            Combine patches from Morphe, ReVanced, RVX, Piko, Patcheddit, Adobo, and the brosssh external-bundles aggregator. Version detection uses union strategy &mdash; the highest version supported by at least one source.
                         </p>
                     </div>
                     <div class="feature-card">
@@ -194,6 +194,7 @@
             <nav class="footer-links" aria-label="Footer navigation">
                 <a href="https://github.com/Ven0m0/Revanced-auto" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
                 <a href="https://github.com/Ven0m0/Revanced-auto/blob/main/CONFIG.md" target="_blank" rel="noopener noreferrer">Config Reference</a>
+                <a href="https://github.com/MorpheApp/morphe-patches" target="_blank" rel="noopener noreferrer">Morphe Patches</a>
                 <a href="https://github.com/ReVanced" target="_blank" rel="noopener noreferrer">ReVanced Project</a>
                 <a href="https://github.com/inotia00/revanced-patches" target="_blank" rel="noopener noreferrer">RVX Patches</a>
             </nav>

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@ uv_venv_create_args = ["--seed", "--system-site-packages"]
 # (mypy, ruff, pytest, prek, ...) live in pyproject.toml dev groups so
 # `uv sync --all-groups` is the single source of truth and `mise install`
 # stays fast and reproducible.
-python = "3.14.6"
+python = "3.13"
 uv = "latest"
 java = "temurin-25.0.3+9.0.LTS"
 

--- a/scripts/builder/app_processor.py
+++ b/scripts/builder/app_processor.py
@@ -266,6 +266,28 @@ class Notifier(Protocol):
         ...
 
 
+def _cli_artifact_name(cli_source: str) -> str:
+    """Derive the CLI JAR artifact prefix from a ``owner/repo`` slug.
+
+    Examples:
+        ``MorpheApp/morphe-cli`` → ``morphe-cli``
+        ``ReVanced/revanced-cli`` → ``revanced-cli``
+        ``inotia00/revanced-cli`` → ``revanced-cli``
+    """
+    return cli_source.rsplit("/", 1)[-1]
+
+
+def _patches_artifact_name(patches_source: str) -> str:
+    """Derive the patches JAR artifact prefix from a ``owner/repo`` slug.
+
+    Examples:
+        ``MorpheApp/morphe-patches`` → ``morphe-patches``
+        ``ReVanced/revanced-patches`` → ``revanced-patches``
+        ``crimera/piko`` → ``piko``
+    """
+    return patches_source.rsplit("/", 1)[-1]
+
+
 class JobRunner:
     """Manages parallel job execution with concurrency limiting.
 
@@ -734,7 +756,11 @@ class AppProcessor:
         from scripts.utils.network import gh_dl
 
         if not cli_jar.exists():
-            cli_url = f"https://github.com/{context.cli_source}/releases/download/v{context.cli_version}/revanced-cli-{context.cli_version}-all.jar"
+            cli_artifact = _cli_artifact_name(context.cli_source)
+            cli_url = (
+                f"https://github.com/{context.cli_source}/releases/download/"
+                f"v{context.cli_version}/{cli_artifact}-{context.cli_version}-all.jar"
+            )
             success = gh_dl(cli_jar, cli_url)
             if not success:
                 raise RuntimeError(f"Failed to download CLI from {cli_url}")
@@ -761,9 +787,10 @@ class AppProcessor:
                 entry = resolve_bundle(selector, context.patches_version)
                 patches_url = entry.download_url
             else:
+                patches_artifact = _patches_artifact_name(patches_src)
                 patches_url = (
                     f"https://github.com/{patches_src}/releases/download/v{context.patches_version}/"
-                    f"revanced-patches-{context.patches_version}.jar"
+                    f"{patches_artifact}-{context.patches_version}.jar"
                 )
 
             success = gh_dl(patches_jar, patches_url)

--- a/scripts/builder/app_processor.py
+++ b/scripts/builder/app_processor.py
@@ -274,7 +274,7 @@ def _cli_artifact_name(cli_source: str) -> str:
         ``ReVanced/revanced-cli`` → ``revanced-cli``
         ``inotia00/revanced-cli`` → ``revanced-cli``
     """
-    return cli_source.rsplit("/", 1)[-1]
+    return cli_source.strip().rstrip("/").rsplit("/", 1)[-1]
 
 
 def _patches_artifact_name(patches_source: str) -> str:
@@ -285,7 +285,7 @@ def _patches_artifact_name(patches_source: str) -> str:
         ``ReVanced/revanced-patches`` → ``revanced-patches``
         ``crimera/piko`` → ``piko``
     """
-    return patches_source.rsplit("/", 1)[-1]
+    return patches_source.strip().rstrip("/").rsplit("/", 1)[-1]
 
 
 class JobRunner:

--- a/tests/test_app_processor.py
+++ b/tests/test_app_processor.py
@@ -128,3 +128,30 @@ class TestArtifactNameDerivation:
     )
     def test_patches_artifact_name(self, repo: str, expected: str) -> None:
         assert _patches_artifact_name(repo) == expected
+
+    @pytest.mark.parametrize(
+        ("repo", "expected"),
+        [
+            ("  MorpheApp/morphe-cli  ", "morphe-cli"),  # whitespace
+            ("MorpheApp/morphe-cli/", "morphe-cli"),      # trailing slash
+            ("  crimera/piko/  ", "piko"),                 # both
+            ("/owner/repo", "repo"),                        # leading slash
+        ],
+    )
+    def test_cli_artifact_name_trims_whitespace_and_slashes(
+        self, repo: str, expected: str
+    ) -> None:
+        assert _cli_artifact_name(repo) == expected
+
+    @pytest.mark.parametrize(
+        ("repo", "expected"),
+        [
+            ("  MorpheApp/morphe-patches  ", "morphe-patches"),
+            ("MorpheApp/morphe-patches/", "morphe-patches"),
+            ("  crimera/piko/  ", "piko"),
+        ],
+    )
+    def test_patches_artifact_name_trims_whitespace_and_slashes(
+        self, repo: str, expected: str
+    ) -> None:
+        assert _patches_artifact_name(repo) == expected

--- a/tests/test_app_processor.py
+++ b/tests/test_app_processor.py
@@ -8,7 +8,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from scripts.builder.app_processor import AppProcessor, Architecture, DownloadSource
+from scripts.builder.app_processor import (
+    AppProcessor,
+    Architecture,
+    DownloadSource,
+    _cli_artifact_name,
+    _patches_artifact_name,
+)
 from scripts.builder.config import AppConfig
 
 
@@ -86,3 +92,39 @@ class TestAppProcessorDownloadSource:
         app_config = AppConfig(name="TestApp", options=options)
         source = processor._determine_download_source(app_config)
         assert source == expected_source
+
+
+class TestArtifactNameDerivation:
+    """Tests for CLI / patches artifact name derivation from repo slugs.
+
+    These guard the regression where the hardcoded ``revanced-cli-`` and
+    ``revanced-patches-`` URLs broke downloads for Morphe, Piko, and other
+    non-ReVanced sources.
+    """
+
+    @pytest.mark.parametrize(
+        ("repo", "expected"),
+        [
+            ("MorpheApp/morphe-cli", "morphe-cli"),
+            ("ReVanced/revanced-cli", "revanced-cli"),
+            ("inotia00/revanced-cli", "revanced-cli"),
+            ("j-hc/revanced-cli", "revanced-cli"),
+            ("jkennethcarino/adobo", "adobo"),
+        ],
+    )
+    def test_cli_artifact_name(self, repo: str, expected: str) -> None:
+        assert _cli_artifact_name(repo) == expected
+
+    @pytest.mark.parametrize(
+        ("repo", "expected"),
+        [
+            ("MorpheApp/morphe-patches", "morphe-patches"),
+            ("ReVanced/revanced-patches", "revanced-patches"),
+            ("anddea/revanced-patches", "revanced-patches"),
+            ("crimera/piko", "piko"),
+            ("wchill/patcheddit", "patcheddit"),
+            ("jkennethcarino/adobo", "adobo"),
+        ],
+    )
+    def test_patches_artifact_name(self, repo: str, expected: str) -> None:
+        assert _patches_artifact_name(repo) == expected


### PR DESCRIPTION
Implements dynamic download URL generation for CLI and patches prebuilts, allowing Morphe, Piko, and other patch sources to work correctly.

- Adds  and  helpers to derive artifact prefixes from repo slugs
- Fixes hardcoded  and  URLs in  to use source-aware artifact names
- Updates docs to reflect Morphe as default and document patch source options
- Adds 11 unit tests for artifact name derivation

Fixes support for:
- Morphe CLI ()
- Morphe Patches ()
- Piko ()
- Patcheddit ()
- Adobo ( - Morphe-compatible patches on Morphe CLI)
- External Bundles ()

Also corrects Python version in  to align with .